### PR TITLE
new strip subclasses, new API, casts to resolve warnings

### DIFF
--- a/include/led-strip.h
+++ b/include/led-strip.h
@@ -32,7 +32,16 @@ class LEDStrip {
 public:
     virtual ~LEDStrip() {};
 
-    inline int pixelCount() const {
+    enum ComponentOrder {
+        Order_RGB = 0x012,
+        Order_RBG = 0x021,
+        Order_GRB = 0x102,
+        Order_GBR = 0x120,
+        Order_BRG = 0x201,
+        Order_BGR = 0x210,
+    };
+
+    int pixelCount() const {
         return pixelCount_;
     }
 
@@ -91,11 +100,16 @@ protected:
 // "spi"       The MultiSPI instance
 // "connector" The connector on the breakout board, such as MultiSPI::SPI_P1
 // "pixelCount"     Number of LEDs.
-LEDStrip *CreateWS2801Strip(MultiSPI *spi, MultiSPI::Pin pin, int pixelCount);
-LEDStrip *CreateLPD6803Strip(MultiSPI *spi, MultiSPI::Pin pin, int pixelCount);
-LEDStrip *CreateLPD8806Strip(MultiSPI *spi, MultiSPI::Pin pin, int pixelCount);
-LEDStrip *CreateAPA102Strip(MultiSPI *spi, MultiSPI::Pin pin, int pixelCount);
-LEDStrip *CreateSK9822Strip(MultiSPI *spi, MultiSPI::Pin pin, int pixelCount);
+LEDStrip *CreateWS2801Strip(MultiSPI *spi, MultiSPI::Pin pin, int pixelCount,
+                            LEDStrip::ComponentOrder component_order);
+LEDStrip *CreateLPD6803Strip(MultiSPI *spi, MultiSPI::Pin pin, int pixelCount,
+                                LEDStrip::ComponentOrder component_order);
+LEDStrip *CreateLPD8806Strip(MultiSPI *spi, MultiSPI::Pin pin, int pixelCount,
+                                LEDStrip::ComponentOrder component_order);
+LEDStrip *CreateAPA102Strip(MultiSPI *spi, MultiSPI::Pin pin, int pixelCount,
+                            LEDStrip::ComponentOrder component_order);
+LEDStrip *CreateSK9822Strip(MultiSPI *spi, MultiSPI::Pin pin, int pixelCount,
+                            LEDStrip::ComponentOrder component_order);
 }
 
 #endif // SPIXELS_LED_STRIP_H

--- a/include/led-strip.h
+++ b/include/led-strip.h
@@ -27,89 +27,63 @@
 
 namespace spixels {
 
-// Red Green Blue color. A color represented by RGB values.
-struct RGBc {
-    RGBc(): r(0), g(0), b(0) {}
-
-    // Creating a color with the Red/Green/Blue components. If you are compiling
-    // with C++11, you can even do that in-line
-    // LEDStrip::SetPixel(0, {255, 255, 255});
-    RGBc(uint8_t red, uint8_t green, uint8_t blue) : r(red), g(green), b(blue) {}
-
-    // Setting a color from a single 24Bit 0xRRGGBB hex-value, e.g. 0xff00ff
-    RGBc(uint32_t hexcolor)
-        : r((hexcolor >> 16) & 0xFF),
-          g((hexcolor >>  8) & 0xFF),
-          b((hexcolor >>  0) & 0xFF) {}
-
-    uint8_t r;
-    uint8_t g;
-    uint8_t b;
-};
-
 // Simplest possible way for a LED strip.
 class LEDStrip {
 public:
-    virtual ~LEDStrip();
+    virtual ~LEDStrip() {};
 
-    // Return number of attached LEDs.
-    inline int pixelCount() const { return pixelCount_; }
-/*
-    // Set pixel color. Input it RGB, output is luminance corrected
-    // you don't have to apply pre-correction.
-    // This is typically the function to use.
-    void SetPixel(int pos, const RGBc& c);
-
-    // Same with explicitly spelled out r,g,b.
-    void SetPixel(int pos, uint8_t r, uint8_t g, uint8_t b) {
-        SetPixel(pos, RGBc(r, g, b));
+    inline int pixelCount() const {
+        return pixelCount_;
     }
 
-    // Set overall brightness for all pixels. Range of [0 .. 255].
-    // This scales the brightness so that it looks linear luminance corrected
-    // for the eye.
-    // This will be only having a somewhat pleasing result for LED strips with
-    // higher PWM resolution (such as APA102).
-*/
-	// 0x10000 for no change in brightness
-	// SetBrightnessScale16() is virtual so that subclasses can prepare special data for scaling
-	void SetBrightnessScale16(uint32_t scale16)
-	{ SetBrightnessScale16(scale16, scale16, scale16); }
-	virtual void SetBrightnessScale16(uint32_t redScale16, uint32_t greenScale16, uint32_t blueScale16)
-    { redScale16_ = redScale16;
-      greenScale16_ = greenScale16;
-      blueScale16_ = blueScale16; }
-    uint32_t redScale16() const
-    { return redScale16_; }
-    uint32_t greenScale16() const
-    { return greenScale16_; }
-    uint32_t blueScale16() const
-    { return blueScale16_; }
-    
-	// The following methods provide different ways of setting a pixel's value:
-	// The maximum value of a uint16_t component is 0xFFFF.  Most subclasses will just throw
-	// away the low byte.  APA102/SK9822 will make use of the extra bnits to set
-	// their "global brightness" values.
+    void SetBrightnessScale(float scale16) {
+        SetBrightnessScale(scale16, scale16, scale16);
+    }
+    // SetBrightnessScale() is virtual so that subclasses can prepare special data for scaling
+    virtual void SetBrightnessScale(float redScale, float greenScale, float blueScale) {
+        redScale_ = redScale;
+        greenScale_ = greenScale;
+        blueScale_ = blueScale;
+
+        redScale16_ = (uint32_t)(redScale * 0x10000 + 0.5f);
+        greenScale16_ = (uint32_t)(greenScale * 0x10000 + 0.5f);
+        blueScale16_ = (uint32_t)(blueScale * 0x10000 + 0.5f);
+    }
+    float redScale() const {
+        return redScale_;
+    }
+    float greenScale() const {
+        return greenScale_;
+    }
+    float blueScale() const {
+        return blueScale_;
+    }
+
+    // The following methods provide different ways of setting a pixel's value:
+    // The maximum value of a uint16_t component is 0xFFFF.  Most subclasses will just throw
+    // away the low byte.  APA102/SK9822 will make use of the extra bnits to set
+    // their "global brightness" values.
     virtual void SetPixel8(uint32_t pixel_index, uint8_t red, uint8_t green, uint8_t blue) = 0;
-    virtual void SetPixel16(uint32_t pixel_index, uint16_t red, uint16_t green, uint16_t blue)
-	{
-		// This default implementation will do for most subclasses, not for APA102/SK9822
-		SetPixel8(pixel_index,
-					(uint8_t)std::min(((uint32_t)red + 0x7Fu) >> 8, 0xFFu),
-					(uint8_t)std::min(((uint32_t)green + 0x7Fu) >> 8, 0xFFu),
-					(uint8_t)std::min(((uint32_t)blue + 0x7Fu) >> 8, 0xFFu));
-	}
-    
+    virtual void SetPixel16(uint32_t pixel_index, uint16_t red, uint16_t green, uint16_t blue) {
+        // This default implementation will do for most subclasses, not for APA102/SK9822
+        SetPixel8(pixel_index,
+                    (uint8_t)std::min(((uint32_t)red + 0x7Fu) >> 8, 0xFFu),
+                    (uint8_t)std::min(((uint32_t)green + 0x7Fu) >> 8, 0xFFu),
+                    (uint8_t)std::min(((uint32_t)blue + 0x7Fu) >> 8, 0xFFu));
+    }
+
 protected:
     LEDStrip(int pixelCount);
 
-    const int pixelCount_;
-    uint32_t redScale16_;
-    uint32_t greenScale16_;
-    uint32_t blueScale16_;
-/*
-    RGBc *const values_;
-*/
+    int         const pixelCount_;
+
+    float       redScale_;
+    float       greenScale_;
+    float       blueScale_;
+
+    uint32_t    redScale16_;
+    uint32_t    greenScale16_;
+    uint32_t    blueScale16_;
 };
 
 // Factories for various LED strips.

--- a/include/led-strip.h
+++ b/include/led-strip.h
@@ -72,40 +72,38 @@ public:
     // higher PWM resolution (such as APA102).
 */
 	// brightnessScale16 is 0x10000 for no change in brightness
-    void SetBrightnessScale16(uint32_t brigthnessScale);
-    inline uint32_t brightnessScale16() const { return brightnessScale16_; }
+	// SetBrightnessScale16() is virtual so that subclasses can prepare special data for scaling
+	virtual void SetBrightnessScale16(uint32_t brightnessScale16)
+    { brightnessScale16_ = brightnessScale16; }
+    uint32_t brightnessScale16() const
+    { return brightnessScale16_; }
     
 	// The following methods provide different ways of setting a pixel's value:
 	// The "8" methods accept RGB components as bytes.  If the gammaTable is non-NULL
 	// these values index the table to get 16-bit values, which are passed to the "16" method.
 	// The "16" methods accept values normalized to 0xFFFF.  (max value == 0xFFFF)
-	// the "brightnessScale" field is normalized to 0x10000 (can be above or below this)
 	// the gammaTable array is 256 16-bit numbers, each normalized to 0xFFFF
-	// brightnessScale is applied AFTER the gammaTable.
-	
-	// Most subclasses will simply use the high 8 bits in their implementations of these methods.
-	// Others, such as APA102LedStrip will use all the bits to 
-
-    virtual void SetPixel8(int pixelIndex, uint8_t red, uint8_t green, uint8_t blue) = 0;
-    virtual void SetPixel16(int pixelIndex,
+	// brightnessScale16_ is applied AFTER the gammaTable.
+    virtual void SetPixel8(uint32_t pixel_index, uint8_t red, uint8_t green, uint8_t blue) = 0;
+    virtual void SetPixel16(uint32_t pixel_index,
 							uint16_t red, uint16_t green, uint16_t blue)
 	{
 		// This default implementation will do for most subclasses, not for APA102
 		red = std::min((red + 0x7F) >> 8, 0xFF);
 		green = std::min((green + 0x7F) >> 8, 0xFF);
 		blue = std::min((blue + 0x7F) >> 8, 0xFF);
-		SetPixel8(pixelIndex, (uint8_t)red, (uint8_t)green, (uint8_t)blue);
+		SetPixel8(pixel_index, (uint8_t)red, (uint8_t)green, (uint8_t)blue);
 	}
-    void SetPixel8(int pixelIndex, uint8_t red, uint8_t green, uint8_t blue,
+    void SetPixel8(uint32_t pixel_index, uint8_t red, uint8_t green, uint8_t blue,
     				uint16_t const gammaTable[256])
     {
     	if (gammaTable)
     	{
-	    	SetPixel16(pixelIndex, gammaTable[red], gammaTable[green], gammaTable[blue]);
+	    	SetPixel16(pixel_index, gammaTable[red], gammaTable[green], gammaTable[blue]);
 	    }
 	    else
 	    {
-	    	SetPixel8(pixelIndex, red, green, blue);
+	    	SetPixel8(pixel_index, red, green, blue);
 	    }
     }
     

--- a/include/led-strip.h
+++ b/include/led-strip.h
@@ -44,6 +44,9 @@ public:
     int pixelCount() const {
         return pixelCount_;
     }
+    int ledsPerPixel() const {
+        return ledsPerPixel_;
+    }
 
     void SetBrightnessScale(float scale16) {
         SetBrightnessScale(scale16, scale16, scale16);
@@ -82,9 +85,10 @@ public:
     }
 
 protected:
-    LEDStrip(int pixelCount);
+    LEDStrip(int pixelCount, int ledsPerPixel);
 
     int         const pixelCount_;
+    int         const ledsPerPixel_;
 
     float       redScale_;
     float       greenScale_;
@@ -100,15 +104,20 @@ protected:
 // "spi"       The MultiSPI instance
 // "connector" The connector on the breakout board, such as MultiSPI::SPI_P1
 // "pixelCount"     Number of LEDs.
-LEDStrip *CreateWS2801Strip(MultiSPI *spi, MultiSPI::Pin pin, int pixelCount,
+LEDStrip *CreateWS2801Strip(MultiSPI *spi, MultiSPI::Pin pin,
+                            int pixelCount, int ledsPerPixel,
                             LEDStrip::ComponentOrder component_order);
-LEDStrip *CreateLPD6803Strip(MultiSPI *spi, MultiSPI::Pin pin, int pixelCount,
+LEDStrip *CreateLPD6803Strip(MultiSPI *spi, MultiSPI::Pin pin,
+                                int pixelCount, int ledsPerPixel,
                                 LEDStrip::ComponentOrder component_order);
-LEDStrip *CreateLPD8806Strip(MultiSPI *spi, MultiSPI::Pin pin, int pixelCount,
+LEDStrip *CreateLPD8806Strip(MultiSPI *spi, MultiSPI::Pin pin,
+                                int pixelCount, int ledsPerPixel,
                                 LEDStrip::ComponentOrder component_order);
-LEDStrip *CreateAPA102Strip(MultiSPI *spi, MultiSPI::Pin pin, int pixelCount,
+LEDStrip *CreateAPA102Strip(MultiSPI *spi, MultiSPI::Pin pin,
+                            int pixelCount, int ledsPerPixel,
                             LEDStrip::ComponentOrder component_order);
-LEDStrip *CreateSK9822Strip(MultiSPI *spi, MultiSPI::Pin pin, int pixelCount,
+LEDStrip *CreateSK9822Strip(MultiSPI *spi, MultiSPI::Pin pin,
+                            int pixelCount, int ledsPerPixel,
                             LEDStrip::ComponentOrder component_order);
 }
 

--- a/include/led-strip.h
+++ b/include/led-strip.h
@@ -70,11 +70,11 @@ public:
     // for the eye.
     // This will be only having a somewhat pleasing result for LED strips with
     // higher PWM resolution (such as APA102).
-    //
-    // Brightness change will take effect with next SendBuffers().
-    void SetBrightness(uint8_t brigthness);
-    inline uint8_t brightness() const { return brightness_; }
 */
+	// brightnessScale16 is 0x10000 for no change in brightness
+    void SetBrightnessScale16(uint32_t brigthnessScale);
+    inline uint32_t brightnessScale16() const { return brightnessScale16_; }
+    
 	// The following methods provide different ways of setting a pixel's value:
 	// The "8" methods accept RGB components as bytes.  If the gammaTable is non-NULL
 	// these values index the table to get 16-bit values, which are passed to the "16" method.
@@ -86,60 +86,26 @@ public:
 	// Most subclasses will simply use the high 8 bits in their implementations of these methods.
 	// Others, such as APA102LedStrip will use all the bits to 
 
-    virtual void SetPixel8(int pixelIndex,
-							uint8_t red, uint8_t green, uint8_t blue) = 0;
+    virtual void SetPixel8(int pixelIndex, uint8_t red, uint8_t green, uint8_t blue) = 0;
     virtual void SetPixel16(int pixelIndex,
-							uint16_t red, uint16_t green, uint16_t blue) = 0;
-	virtual void SetPixel8(int pixelIndex,
-							uint8_t red, uint8_t green, uint8_t blue,
-							uint32_t brightnessScale)
+							uint16_t red, uint16_t green, uint16_t blue)
 	{
 		// This default implementation will do for most subclasses, not for APA102
-    	if (brightnessScale > 0x10000)
-    	{
-    		red = (uint8_t)std::min(red * brightnessScale / 0x10000, (uint32_t)0xFF);
-    		green = (uint8_t)std::min(green * brightnessScale / 0x10000, (uint32_t)0xFF);
-    		blue = (uint8_t)std::min(blue * brightnessScale / 0x10000, (uint32_t)0xFF);
-    	}
-    	else if (brightnessScale < 0x10000)
-    	{
-    		red = (uint8_t)(red * brightnessScale / 0x10000);
-    		green = (uint8_t)(green * brightnessScale / 0x10000);
-    		blue = (uint8_t)(blue * brightnessScale / 0x10000);
-    	}
-    	SetPixel8(pixelIndex, red, green, blue);
-	}
-    virtual void SetPixel16(int pixelIndex,
-                            uint16_t red, uint16_t green, uint16_t blue,
-                            uint32_t brightnessScale)
-	{
-		// This default implementation will do for most subclasses, not for APA102
-    	if (brightnessScale > 0x10000)
-    	{
-    		red = (uint16_t)std::min(red * brightnessScale / 0x10000, (uint32_t)0xFFFF);
-    		green = (uint16_t)std::min(green * brightnessScale / 0x10000, (uint32_t)0xFFFF);
-    		blue = (uint16_t)std::min(blue * brightnessScale / 0x10000, (uint32_t)0xFFFF);
-    	}
-    	else if (brightnessScale < 0x10000)
-    	{
-    		red = (uint16_t)(red * brightnessScale / 0x10000);
-    		green = (uint16_t)(green * brightnessScale / 0x10000);
-    		blue = (uint16_t)(blue * brightnessScale / 0x10000);
-    	}
-    	SetPixel16(pixelIndex, red, green, blue);
+		red = std::min((red + 0x7F) >> 8, 0xFF);
+		green = std::min((green + 0x7F) >> 8, 0xFF);
+		blue = std::min((blue + 0x7F) >> 8, 0xFF);
+		SetPixel8(pixelIndex, (uint8_t)red, (uint8_t)green, (uint8_t)blue);
 	}
     void SetPixel8(int pixelIndex, uint8_t red, uint8_t green, uint8_t blue,
-    				uint16_t const gammaTable[256], uint32_t brightnessScale)
+    				uint16_t const gammaTable[256])
     {
     	if (gammaTable)
     	{
-	    	SetPixel16(pixelIndex,
-    					gammaTable[red], gammaTable[green], gammaTable[blue],
-    					brightnessScale);
+	    	SetPixel16(pixelIndex, gammaTable[red], gammaTable[green], gammaTable[blue]);
 	    }
 	    else
 	    {
-	    	SetPixel8(pixelIndex, red, green, blue, brightnessScale);
+	    	SetPixel8(pixelIndex, red, green, blue);
 	    }
     }
     
@@ -147,9 +113,9 @@ protected:
     LEDStrip(int pixelCount);
 
     const int pixelCount_;
+    uint32_t brightnessScale16_;
 /*
     RGBc *const values_;
-    uint8_t brightness_;
 */
 };
 

--- a/include/multi-spi.h
+++ b/include/multi-spi.h
@@ -35,7 +35,7 @@ namespace spixels {
 class MultiSPI {
 public:
     // Names of the pin-headers on the breakout board.
-    enum {
+    enum Pin {
         SPI_CLOCK = 27,
 
         SPI_P1  = 18,
@@ -59,7 +59,7 @@ public:
 
     // A function that maps the connector number (P1..P16) to the value of
     // the corresponding SPI Pin SPI_P1..SPI_P16 constant.
-    static int SPIPinForConnector(int connector);
+    static Pin SPIPinForConnector(int connector);
 
     virtual ~MultiSPI() {}
 
@@ -77,7 +77,7 @@ public:
     // Set data byte for given gpio channel at given position in the
     // stream. "pos" needs to be in range [0 .. serial_bytes_per_stream)
     // Data is sent with next Send().
-    virtual void SetBufferedByte(int data_gpio, size_t pos, uint8_t data) = 0;
+    virtual void SetBufferedByte(Pin pin, size_t pos, uint8_t data) = 0;
 
     // Send data for all streams. Wait for completion. After SendBuffers()
     // has been called once, no new GPIOs can be registered.
@@ -96,7 +96,7 @@ public:
 //   Default is 4. Increase if your set-up can do more and you need the
 //   speed. Decrease if you see erratic behavior.
 MultiSPI *CreateDirectMultiSPI(int speed_mhz = 4,
-                               int clock_gpio = MultiSPI::SPI_CLOCK);
+                               MultiSPI::Pin clockPin = MultiSPI::SPI_CLOCK);
 
 // Factory to create a MultiSPI implementation that uses DMA to output.
 // Advantages:
@@ -106,7 +106,7 @@ MultiSPI *CreateDirectMultiSPI(int speed_mhz = 4,
 //   - Limited speed (1-2Mhz). Good for WS2801 which can't go faster
 //     anyway, but wasting potential with LPD6803 or APA102 that can go
 //     much faster.
-MultiSPI *CreateDMAMultiSPI(int clock_gpio = MultiSPI::SPI_CLOCK);
+MultiSPI *CreateDMAMultiSPI(MultiSPI::Pin clockPin = MultiSPI::SPI_CLOCK);
 }
 
 #endif  // SPIXELS_MULTI_SPI_H

--- a/include/multi-spi.h
+++ b/include/multi-spi.h
@@ -97,7 +97,7 @@ public:
 //   "speed_mhz" rough speed in Mhz of the SPI clock. Useful values 1..15
 //   Default is 4. Increase if your set-up can do more and you need the
 //   speed. Decrease if you see erratic behavior.
-MultiSPI *CreateDirectMultiSPI(int speed_mhz = 4,
+MultiSPI *CreateDirectMultiSPI(double speed_mhz = 4.0,
                                MultiSPI::Pin clockPin = MultiSPI::SPI_CLOCK);
 
 // Factory to create a MultiSPI implementation that uses DMA to output.

--- a/include/multi-spi.h
+++ b/include/multi-spi.h
@@ -21,7 +21,9 @@
 #include <stdint.h>
 #include <stddef.h>
 
+
 namespace spixels {
+
 // MultiSPI outputs multiple SPI streams in parallel on different GPIOs.
 // The clock is on a single GPIO-pin. This way, we can transmit 25-ish
 // SPI streams in parallel on a Pi with 40 IO pins.

--- a/lib/direct-multi-spi.cc
+++ b/lib/direct-multi-spi.cc
@@ -115,43 +115,45 @@ bool DirectMultiSPI::RegisterDataGPIO(int gpio, size_t serial_byte_size)
 void DirectMultiSPI::SetBufferedByte(MultiSPI::Pin pin, size_t pos, uint8_t data)
 {
 	assert(pos < size_);
-	
-	uint32_t		const pinBit = 1 << pin;
-	uint32_t		const pinNotBit = ~pinBit;
-	uint32_t*		buffer_pos = gpio_data_ + 8 * pos;
+	if (pos < size_)
+	{
+		uint32_t		const pinBit = 1 << pin;
+		uint32_t		const pinNotBit = ~pinBit;
+		uint32_t*		buffer_pos = gpio_data_ + 8 * pos;
 
 #if 1
-	for (uint8_t bit = 0x80; bit; bit >>= 1)
-	{
-		if (data & bit)
-		{   // set
-			*buffer_pos |= pinBit;
+		for (uint8_t bit = 0x80; bit; bit >>= 1)
+		{
+			if (data & bit)
+			{   // set
+				*buffer_pos |= pinBit;
+			}
+			else
+			{  // reset
+				*buffer_pos &= pinNotBit;
+			}
+			buffer_pos++;
 		}
-		else
-		{  // reset
-			*buffer_pos &= pinNotBit;
-		}
-		buffer_pos++;
-	}
 #else
-	// This unwound loop has no conditional branches, no broken pipeline!
-	// Yet it goes slower than the above loop on the Pi.  Go figure...
-	buffer_pos[7] = (buffer_pos[7] & pinNotBit) | ((data & 1) << pin);
-	data >>= 1;
-	buffer_pos[6] = (buffer_pos[6] & pinNotBit) | ((data & 1) << pin);
-	data >>= 1;
-	buffer_pos[5] = (buffer_pos[5] & pinNotBit) | ((data & 1) << pin);
-	data >>= 1;
-	buffer_pos[4] = (buffer_pos[4] & pinNotBit) | ((data & 1) << pin);
-	data >>= 1;
-	buffer_pos[3] = (buffer_pos[3] & pinNotBit) | ((data & 1) << pin);
-	data >>= 1;
-	buffer_pos[2] = (buffer_pos[2] & pinNotBit) | ((data & 1) << pin);
-	data >>= 1;
-	buffer_pos[1] = (buffer_pos[1] & pinNotBit) | ((data & 1) << pin);
-	data >>= 1;
-	buffer_pos[0] = (buffer_pos[0] & pinNotBit) | ((data & 1) << pin);
+		// This unwound loop has no conditional branches, no broken pipeline!
+		// Yet it goes slower than the above loop on the Pi.  Go figure...
+		buffer_pos[7] = (buffer_pos[7] & pinNotBit) | ((data & 1) << pin);
+		data >>= 1;
+		buffer_pos[6] = (buffer_pos[6] & pinNotBit) | ((data & 1) << pin);
+		data >>= 1;
+		buffer_pos[5] = (buffer_pos[5] & pinNotBit) | ((data & 1) << pin);
+		data >>= 1;
+		buffer_pos[4] = (buffer_pos[4] & pinNotBit) | ((data & 1) << pin);
+		data >>= 1;
+		buffer_pos[3] = (buffer_pos[3] & pinNotBit) | ((data & 1) << pin);
+		data >>= 1;
+		buffer_pos[2] = (buffer_pos[2] & pinNotBit) | ((data & 1) << pin);
+		data >>= 1;
+		buffer_pos[1] = (buffer_pos[1] & pinNotBit) | ((data & 1) << pin);
+		data >>= 1;
+		buffer_pos[0] = (buffer_pos[0] & pinNotBit) | ((data & 1) << pin);
 #endif
+	}
 }
 
 void DirectMultiSPI::SendBuffers()

--- a/lib/direct-multi-spi.cc
+++ b/lib/direct-multi-spi.cc
@@ -30,8 +30,10 @@ namespace spixels {
 
 // This should be in a multi-spi.cc, but that would be the only function. So
 // here is good as well.
-int MultiSPI::SPIPinForConnector(int connector) {
+MultiSPI::Pin MultiSPI::SPIPinForConnector(int connector) {
     switch (connector) {
+    default :
+    	assert(false);
     case 1:  return SPI_P1;
     case 2:  return SPI_P2;
     case 3:  return SPI_P3;
@@ -50,21 +52,20 @@ int MultiSPI::SPIPinForConnector(int connector) {
     case 15: return SPI_P15;
     case 16: return SPI_P16;
     }
-    return -1;
 }
 
 namespace {
 class DirectMultiSPI : public MultiSPI {
 public:
-    explicit DirectMultiSPI(int speed_mhz, int clock_gpio);
+    explicit DirectMultiSPI(int speed_mhz, MultiSPI::Pin clockPin);
     virtual ~DirectMultiSPI();
 
     virtual bool RegisterDataGPIO(int gpio, size_t serial_byte_size);
-    virtual void SetBufferedByte(int data_gpio, size_t pos, uint8_t data);
+    virtual void SetBufferedByte(MultiSPI::Pin pin, size_t pos, uint8_t data);
     virtual void SendBuffers();
 
 private:
-    const int clock_gpio_;
+    const MultiSPI::Pin clockPin_;
     const int write_repeat_;  // how often write operations to repeat to slowdown
     ft::GPIO gpio_;
     size_t size_;
@@ -72,26 +73,35 @@ private:
 };
 }  // end anonymous namespace
 
-DirectMultiSPI::DirectMultiSPI(int speed_mhz, int clock_gpio)
-    : clock_gpio_(clock_gpio),
-      write_repeat_(std::max(2, (int)roundf(30.0 / speed_mhz))),
-      size_(0), gpio_data_(NULL) {
+DirectMultiSPI::DirectMultiSPI(int speed_mhz, MultiSPI::Pin clockPin)
+: clockPin_(clockPin)
+, write_repeat_(std::max(2, (int)roundf(30.0 / speed_mhz)))
+, size_(0)
+, gpio_data_(NULL)
+{
     bool success = gpio_.Init();
     assert(success);  // gpio couldn't be initialized
-    success = gpio_.AddOutput(clock_gpio);
+    success = gpio_.AddOutput(clockPin);
     assert(success);  // clock pin not valid
 }
 
-DirectMultiSPI::~DirectMultiSPI() {
-    free(gpio_data_);
+DirectMultiSPI::~DirectMultiSPI()
+{
+	if (gpio_data_)
+	{
+	    free(gpio_data_);
+	}
 }
 
-bool DirectMultiSPI::RegisterDataGPIO(int gpio, size_t serial_byte_size) {
-    if (serial_byte_size > size_) {
+bool DirectMultiSPI::RegisterDataGPIO(int gpio, size_t serial_byte_size)
+{
+    if (serial_byte_size > size_)
+    {
         const int prev_size = size_ * 8 * sizeof(uint32_t);
         const int new_size = serial_byte_size * 8 * sizeof(uint32_t);
         size_ = serial_byte_size;
-	if (gpio_data_ == NULL) {
+		if (gpio_data_ == NULL)
+		{
             gpio_data_ = (uint32_t*)malloc(new_size);
         } else {
             gpio_data_ = (uint32_t*)realloc(gpio_data_, new_size);
@@ -102,31 +112,75 @@ bool DirectMultiSPI::RegisterDataGPIO(int gpio, size_t serial_byte_size) {
     return gpio_.AddOutput(gpio);
 }
 
-void DirectMultiSPI::SetBufferedByte(int data_gpio, size_t pos, uint8_t data) {
-    assert(pos < size_);
-    uint32_t *buffer_pos = gpio_data_ + 8 * pos;
-    for (uint8_t bit = 0x80; bit; bit >>= 1, buffer_pos++) {
-        if (data & bit) {   // set
-            *buffer_pos |= (1 << data_gpio);
-        } else {  // reset
-            *buffer_pos &= ~(1 << data_gpio);
-        }
-    }
+void DirectMultiSPI::SetBufferedByte(MultiSPI::Pin pin, size_t pos, uint8_t data)
+{
+	assert(pos < size_);
+	
+	uint32_t		const pinBit = 1 << pin;
+	uint32_t		const pinNotBit = ~pinBit;
+	uint32_t*		buffer_pos = gpio_data_ + 8 * pos;
+
+#if 1
+	for (uint8_t bit = 0x80; bit; bit >>= 1)
+	{
+		if (data & bit)
+		{   // set
+			*buffer_pos |= pinBit;
+		}
+		else
+		{  // reset
+			*buffer_pos &= pinNotBit;
+		}
+		buffer_pos++;
+	}
+#else
+	// This unwound loop has no conditional branches, no broken pipeline!
+	// Yet it goes slower than the above loop on the Pi.  Go figure...
+	buffer_pos[7] = (buffer_pos[7] & pinNotBit) | ((data & 1) << pin);
+	data >>= 1;
+	buffer_pos[6] = (buffer_pos[6] & pinNotBit) | ((data & 1) << pin);
+	data >>= 1;
+	buffer_pos[5] = (buffer_pos[5] & pinNotBit) | ((data & 1) << pin);
+	data >>= 1;
+	buffer_pos[4] = (buffer_pos[4] & pinNotBit) | ((data & 1) << pin);
+	data >>= 1;
+	buffer_pos[3] = (buffer_pos[3] & pinNotBit) | ((data & 1) << pin);
+	data >>= 1;
+	buffer_pos[2] = (buffer_pos[2] & pinNotBit) | ((data & 1) << pin);
+	data >>= 1;
+	buffer_pos[1] = (buffer_pos[1] & pinNotBit) | ((data & 1) << pin);
+	data >>= 1;
+	buffer_pos[0] = (buffer_pos[0] & pinNotBit) | ((data & 1) << pin);
+#endif
 }
 
-void DirectMultiSPI::SendBuffers() {
-    uint32_t *end = gpio_data_ + 8 * size_;
-    for (uint32_t *data = gpio_data_; data < end; ++data) {
-        uint32_t d = *data;
-        for (int i = 0; i < write_repeat_; ++i) gpio_.Write(d);
-        d |= (1 << clock_gpio_);   // pos clock edge.
-        for (int i = 0; i < write_repeat_; ++i) gpio_.Write(d);
-    }
-    gpio_.Write(0);  // Reset clock.
+void DirectMultiSPI::SendBuffers()
+{
+	uint32_t*		const end = gpio_data_ + 8 * size_;
+	
+	for (uint32_t *data = gpio_data_; data < end; ++data)
+	{
+	    uint32_t		d;
+	    
+	    d = *data;
+	    for (int i = 0; i < write_repeat_; ++i)
+	    {
+	    	gpio_.Write(d);
+	    }
+	    
+	    d |= 1 << clockPin_;   // pos clock edge.
+	    for (int i = 0; i < write_repeat_; ++i)
+	    {
+	    	gpio_.Write(d);
+	    }
+	}
+	gpio_.Write(0);  // Reset clock.
 }
 
 // Public interface
-MultiSPI *CreateDirectMultiSPI(int speed_mhz, int clock_gpio) {
-    return new DirectMultiSPI(speed_mhz, clock_gpio);
+MultiSPI *CreateDirectMultiSPI(int speed_mhz, MultiSPI::Pin clockPin) {
+    return new DirectMultiSPI(speed_mhz, clockPin);
 }
+
+
 }  // namespace spixels

--- a/lib/direct-multi-spi.cc
+++ b/lib/direct-multi-spi.cc
@@ -25,6 +25,11 @@
 #include <stdlib.h>
 #include <string.h>
 #include <algorithm>
+#include <time.h>       // for ::clock_gettime()
+#include <stdio.h>      // for ::printf()
+
+
+#define DO_LOG_TIMING   0
 
 namespace spixels {
 
@@ -58,7 +63,7 @@ namespace {
 
 class DirectMultiSPI : public MultiSPI {
 public:
-    explicit DirectMultiSPI(int speed_mhz, MultiSPI::Pin clockPin);
+    explicit DirectMultiSPI(double speed_mhz, MultiSPI::Pin clockPin);
     virtual ~DirectMultiSPI();
 
     virtual bool RegisterDataGPIO(int gpio, size_t serial_byte_size);
@@ -66,17 +71,36 @@ public:
     virtual void SendBuffers();
 
 private:
-    const MultiSPI::Pin clockPin_;
-    const int write_repeat_;  // how often write operations to repeat to slowdown
-    ft::GPIO gpio_;
-    size_t size_;
-    uint32_t *gpio_data_;
+    MultiSPI::Pin   const clockPin_;
+    double          const gpio_mhz_;
+    ft::GPIO        gpio_;
+    size_t          size_;
+    uint32_t*       gpio_data_;
+    double          static gpio_duration_;          // how long it takes to write to GPIO
+    double          static busy_cycle_duration_;    // how long it takes to loop doing a single memory write
+    bool            static durations_measured_;     // whether the above durations have been measured.
+    int             static const minimum_gpio_count_ = 3;
+    int             extra_gpio_count_;
+    int             busy_cycle_count_;
+    int             volatile busy_cycle_sink_;      // written to during busy cycles
+
+    void            MeasureSendBuffersDurations();
+    void            CalculateSendBuffersTiming();
+    void            SendBuffers(int extra_gpio_count, int busy_cycle_count);
 };
 
 }  // end anonymous namespace
 
-DirectMultiSPI::DirectMultiSPI(int speed_mhz, MultiSPI::Pin clockPin)
-: clockPin_(clockPin), write_repeat_(std::max(2, (int)roundf(30.0f / speed_mhz))), size_(0), gpio_data_(NULL) {
+double          DirectMultiSPI::gpio_duration_ = 17.2 / 1000000000;      // default, measured on Pi 3B
+double          DirectMultiSPI::busy_cycle_duration_ = 5.0 / 1000000000; // default, measured on Pi 3B
+bool            DirectMultiSPI::durations_measured_ = false;             // causes above durations to be measured in SendBuffer()
+
+DirectMultiSPI::DirectMultiSPI(double speed_mhz, MultiSPI::Pin clockPin)
+: clockPin_(clockPin),
+  gpio_mhz_(speed_mhz),
+  size_(0),
+  gpio_data_(NULL) {
+    CalculateSendBuffersTiming();
     bool success = gpio_.Init();
     assert(success);  // gpio couldn't be initialized
     success = gpio_.AddOutput(clockPin);
@@ -87,6 +111,67 @@ DirectMultiSPI::~DirectMultiSPI() {
     if (gpio_data_) {
         free(gpio_data_);
     }
+}
+
+void DirectMultiSPI::MeasureSendBuffersDurations()
+{
+    struct timespec spec;
+
+    if (::clock_gettime(CLOCK_MONOTONIC, &spec) == 0) {
+        double          const start_time = spec.tv_sec + spec.tv_nsec * 0.000000001;
+
+        SendBuffers(100, 0);
+        // if clock_gettime() worked the first time, we'll assume it will again:
+        ::clock_gettime(CLOCK_MONOTONIC, &spec);
+
+        double          const mid_time = spec.tv_sec + spec.tv_nsec * 0.000000001;
+        int             i;
+
+        for (i = 0; i < 0x100000; ++i) {
+            busy_cycle_sink_ = i;
+        }
+        ::clock_gettime(CLOCK_MONOTONIC, &spec);
+
+        double          const end_time = spec.tv_sec + spec.tv_nsec * 0.000000001;
+        double          const gpio_duration = mid_time - start_time;
+        double          const busy_duration = end_time - mid_time;
+        unsigned long   const bit_count = 8 * size_ + 1;
+
+        gpio_duration_ = gpio_duration / (bit_count * (minimum_gpio_count_ + 100) + 1);
+        busy_cycle_duration_ = busy_duration / 0x100000;
+#if DO_LOG_TIMING
+        ::printf("DirectMultiSPI::MeasureSendBuffersDurations() - GPIO duration = %1.3fns, busy duration = %1.3fns\n",
+                    gpio_duration_ * 1000000000, busy_cycle_duration_ * 1000000000);
+#endif
+        durations_measured_ = true;
+        CalculateSendBuffersTiming();
+    }
+}
+void DirectMultiSPI::CalculateSendBuffersTiming() {
+    double          const target_bit_duration = 0.000001 / gpio_mhz_;
+    double          const minimum_bit_duration = minimum_gpio_count_ * gpio_duration_;
+    double          const delay = target_bit_duration - minimum_bit_duration;
+    double          delay_remainder;
+
+    if (delay > 0.0) {
+        extra_gpio_count_ = (int)(delay / gpio_duration_);
+        delay_remainder = delay - extra_gpio_count_ * gpio_duration_;
+        busy_cycle_count_ = (int)(delay_remainder / busy_cycle_duration_);
+    } else {
+        // Set the busy delay to zero.
+        extra_gpio_count_ = 0;
+        busy_cycle_count_ = 0;
+    }
+    // For some reason, the measured data frequency is more accurate if we
+    // tweak the count like this:
+    extra_gpio_count_++;
+
+#if DO_LOG_TIMING
+    if (durations_measured_) {
+        ::printf("DirectMultiSPI::CalculateSendBuffersTiming() - %1.1fMHz, delay = %1.3fns, extra GPIOs = %u, busy cycles = %u\n",
+                    gpio_mhz_, delay * 1000000000, extra_gpio_count_, busy_cycle_count_);
+    }
+#endif
 }
 
 bool DirectMultiSPI::RegisterDataGPIO(int gpio, size_t serial_byte_size) {
@@ -122,7 +207,7 @@ void DirectMultiSPI::SetBufferedByte(MultiSPI::Pin pin, size_t pos, uint8_t data
             }
             buffer_pos++;
         }
-#else
+#elif 0
         // This unwound loop has no conditional branches, no broken pipeline!
         // Yet it goes slower than the above loop on the Pi.
         // Maybe someday figure out why...
@@ -141,31 +226,91 @@ void DirectMultiSPI::SetBufferedByte(MultiSPI::Pin pin, size_t pos, uint8_t data
         buffer_pos[1] = (buffer_pos[1] & pin_not_bit) | ((data & 1) << pin);
         data >>= 1;
         buffer_pos[0] = (buffer_pos[0] & pin_not_bit) | ((data & 1) << pin);
+#else
+        // This option is slower as well, even though it has fewer conditional branches...
+        uint32_t*       const buffer_end = buffer_pos;
+
+        buffer_pos += 7;
+        do
+        {
+            *buffer_pos = (*buffer_pos & pin_not_bit) | ((data & 1) << pin);
+            data >>= 1;
+        }
+        while (--buffer_pos >= buffer_end);
 #endif
     }
 }
 
 void DirectMultiSPI::SendBuffers() {
-    uint32_t*       const end = gpio_data_ + 8 * size_;
-    
+    if (!durations_measured_) {
+        MeasureSendBuffersDurations();
+    }
+    SendBuffers(extra_gpio_count_, busy_cycle_count_);
+}
+void DirectMultiSPI::SendBuffers(int extra_gpio_count, int busy_cycle_count) {
+    int             const extra_gpio_count1 = extra_gpio_count / 2;
+    int             const extra_gpio_count2 = extra_gpio_count - extra_gpio_count1;
+    int             const busy_cycle_count1 = busy_cycle_count / 2;
+    int             const busy_cycle_count2 = busy_cycle_count - busy_cycle_count1;
+    unsigned long   const bit_count = 8 * size_;
+    uint32_t*       const end = gpio_data_ + bit_count;
+
+#if DO_LOG_TIMING
+    struct timespec spec;
+
+    ::clock_gettime(CLOCK_MONOTONIC, &spec);
+
+    double          const start_time = spec.tv_sec + spec.tv_nsec * 0.000000001;
+#endif
+
     for (uint32_t *data = gpio_data_; data < end; ++data) {
         uint32_t        d;
-        
+        int             i;
+/*
+        The way this SHOULD work is that we write to GPIO 3 times (1 to clear bits,
+        1 to set the data bits, 1 to add the clock bit), then spend many cycles
+        in a loop doing nothing.  For some reason, this causes flickery display
+        on the LEDs.  What DOES work is to spend time setting the GPIO pins
+        repeatedly, so that's what we do!
+*/
+        // first, set the data bits
         d = *data;
-        for (int i = 0; i < write_repeat_; ++i) {
-            gpio_.Write(d);
+        gpio_.Write(d);     // one GPIO clear-bits and one GPIO set-bits
+        for (i = 0; i < extra_gpio_count1; ++i) {
+            gpio_.Set(d);
         }
-        
-        d |= 1 << clockPin_;   // pos clock edge.
-        for (int i = 0; i < write_repeat_; ++i) {
-            gpio_.Write(d);
+        for (i = 0; i < busy_cycle_count1; ++i) {
+            busy_cycle_sink_ = i;
+        }
+
+        // then set the clock bit high so that the LED chips will take in the data bits
+        d |= 1 << clockPin_;
+        gpio_.Set(d);
+        for (i = 0; i < extra_gpio_count2; ++i) {
+            gpio_.Set(d);
+        }
+        for (i = 0; i < busy_cycle_count2; ++i) {
+            busy_cycle_sink_ = i;
         }
     }
-    gpio_.Write(0);  // Reset clock.
+
+    // clear the clock and data bits
+    gpio_.Clear(0xFFFFFFFF);    // one GPIO clear-bits
+
+#if DO_LOG_TIMING
+    ::clock_gettime(CLOCK_MONOTONIC, &spec);
+
+    double          const end_time = spec.tv_sec + spec.tv_nsec * 0.000000001;
+    double          const duration = end_time - start_time;
+    double          const ns_per_bit = duration * 1000000000 / bit_count;
+    double          const mhz = 1000.0 / ns_per_bit;
+
+    ::printf("DirectMultiSPI::SendBuffers() - bit duration = %1.3fns : %1.3fMHz\n", ns_per_bit, mhz);
+#endif
 }
 
 // Public interface
-MultiSPI *CreateDirectMultiSPI(int speed_mhz, MultiSPI::Pin clockPin) {
+MultiSPI *CreateDirectMultiSPI(double speed_mhz, MultiSPI::Pin clockPin) {
     return new DirectMultiSPI(speed_mhz, clockPin);
 }
 

--- a/lib/direct-multi-spi.cc
+++ b/lib/direct-multi-spi.cc
@@ -117,8 +117,8 @@ void DirectMultiSPI::SetBufferedByte(MultiSPI::Pin pin, size_t pos, uint8_t data
 	assert(pos < size_);
 	if (pos < size_)
 	{
-		uint32_t		const pinBit = 1 << pin;
-		uint32_t		const pinNotBit = ~pinBit;
+		uint32_t		const pin_bit = 1 << pin;
+		uint32_t		const pin_not_bit = ~pin_bit;
 		uint32_t*		buffer_pos = gpio_data_ + 8 * pos;
 
 #if 1
@@ -126,32 +126,32 @@ void DirectMultiSPI::SetBufferedByte(MultiSPI::Pin pin, size_t pos, uint8_t data
 		{
 			if (data & bit)
 			{   // set
-				*buffer_pos |= pinBit;
+				*buffer_pos |= pin_bit;
 			}
 			else
 			{  // reset
-				*buffer_pos &= pinNotBit;
+				*buffer_pos &= pin_not_bit;
 			}
 			buffer_pos++;
 		}
 #else
 		// This unwound loop has no conditional branches, no broken pipeline!
 		// Yet it goes slower than the above loop on the Pi.  Go figure...
-		buffer_pos[7] = (buffer_pos[7] & pinNotBit) | ((data & 1) << pin);
+		buffer_pos[7] = (buffer_pos[7] & pin_not_bit) | ((data & 1) << pin);
 		data >>= 1;
-		buffer_pos[6] = (buffer_pos[6] & pinNotBit) | ((data & 1) << pin);
+		buffer_pos[6] = (buffer_pos[6] & pin_not_bit) | ((data & 1) << pin);
 		data >>= 1;
-		buffer_pos[5] = (buffer_pos[5] & pinNotBit) | ((data & 1) << pin);
+		buffer_pos[5] = (buffer_pos[5] & pin_not_bit) | ((data & 1) << pin);
 		data >>= 1;
-		buffer_pos[4] = (buffer_pos[4] & pinNotBit) | ((data & 1) << pin);
+		buffer_pos[4] = (buffer_pos[4] & pin_not_bit) | ((data & 1) << pin);
 		data >>= 1;
-		buffer_pos[3] = (buffer_pos[3] & pinNotBit) | ((data & 1) << pin);
+		buffer_pos[3] = (buffer_pos[3] & pin_not_bit) | ((data & 1) << pin);
 		data >>= 1;
-		buffer_pos[2] = (buffer_pos[2] & pinNotBit) | ((data & 1) << pin);
+		buffer_pos[2] = (buffer_pos[2] & pin_not_bit) | ((data & 1) << pin);
 		data >>= 1;
-		buffer_pos[1] = (buffer_pos[1] & pinNotBit) | ((data & 1) << pin);
+		buffer_pos[1] = (buffer_pos[1] & pin_not_bit) | ((data & 1) << pin);
 		data >>= 1;
-		buffer_pos[0] = (buffer_pos[0] & pinNotBit) | ((data & 1) << pin);
+		buffer_pos[0] = (buffer_pos[0] & pin_not_bit) | ((data & 1) << pin);
 #endif
 	}
 }

--- a/lib/direct-multi-spi.cc
+++ b/lib/direct-multi-spi.cc
@@ -75,7 +75,7 @@ private:
 
 DirectMultiSPI::DirectMultiSPI(int speed_mhz, MultiSPI::Pin clockPin)
 : clockPin_(clockPin)
-, write_repeat_(std::max(2, (int)roundf(30.0 / speed_mhz)))
+, write_repeat_(std::max(2, (int)roundf(30.0f / speed_mhz)))
 , size_(0)
 , gpio_data_(NULL)
 {
@@ -97,8 +97,8 @@ bool DirectMultiSPI::RegisterDataGPIO(int gpio, size_t serial_byte_size)
 {
     if (serial_byte_size > size_)
     {
-        const int prev_size = size_ * 8 * sizeof(uint32_t);
-        const int new_size = serial_byte_size * 8 * sizeof(uint32_t);
+        const size_t prev_size = size_ * 8 * sizeof(uint32_t);
+        const size_t new_size = serial_byte_size * 8 * sizeof(uint32_t);
         size_ = serial_byte_size;
 		if (gpio_data_ == NULL)
 		{

--- a/lib/dma-multi-spi.cc
+++ b/lib/dma-multi-spi.cc
@@ -84,11 +84,11 @@ namespace spixels {
 namespace {
 class DMAMultiSPI : public MultiSPI {
 public:
-    explicit DMAMultiSPI(int clock_gpio);
+    explicit DMAMultiSPI(MultiSPI::Pin clockPin);
     virtual ~DMAMultiSPI();
 
     virtual bool RegisterDataGPIO(int gpio, size_t serial_byte_size);
-    virtual void SetBufferedByte(int data_gpio, size_t pos, uint8_t data);
+    virtual void SetBufferedByte(MultiSPI::Pin pin, size_t pos, uint8_t data);
     virtual void SendBuffers();
 
 private:
@@ -96,7 +96,7 @@ private:
 
     struct GPIOData;
     ft::GPIO gpio_;
-    const int clock_gpio_;
+    const MultiSPI::Pin clockPin_;
     size_t serial_byte_size_;   // Number of serial bytes to send.
 
     struct UncachedMemBlock alloced_;
@@ -116,13 +116,13 @@ struct DMAMultiSPI::GPIOData {
     uint32_t clr;
 };
 
-DMAMultiSPI::DMAMultiSPI(int clock_gpio)
-    : clock_gpio_(clock_gpio), serial_byte_size_(0),
+DMAMultiSPI::DMAMultiSPI(MultiSPI::Pin clockPin)
+    : clockPin_(clockPin), serial_byte_size_(0),
       gpio_dma_(NULL), gpio_shadow_(NULL) {
     alloced_.mem = NULL;
     bool success = gpio_.Init();
     assert(success);  // gpio couldn't be initialized
-    success = gpio_.AddOutput(clock_gpio);
+    success = gpio_.AddOutput(clockPin);
     assert(success);  // clock pin not valid
 }
 
@@ -165,9 +165,9 @@ bool DMAMultiSPI::RegisterDataGPIO(int gpio, size_t requested_bytes) {
         // Even: data, clock low; Uneven: clock pos edge
         for (int i = prev_gpio_end; i < gpio_operations; ++i) {
             if (i % 2 == 0)
-                gpio_shadow_[i].clr = (1<<clock_gpio_);
+                gpio_shadow_[i].clr = (1<<clockPin_);
             else
-                gpio_shadow_[i].set = (1<<clock_gpio_);
+                gpio_shadow_[i].set = (1<<clockPin_);
         }
     }
 
@@ -218,17 +218,27 @@ void DMAMultiSPI::FinishRegistration() {
     dma_channel_ = (struct dma_channel_header*)(dmaBase + 0x100 * DMA_CHANNEL);
 }
 
-void DMAMultiSPI::SetBufferedByte(int data_gpio, size_t pos, uint8_t data) {
+void DMAMultiSPI::SetBufferedByte(MultiSPI::Pin pin, size_t pos, uint8_t data)
+{
     assert(pos < serial_byte_size_);
-    GPIOData *buffer_pos = gpio_shadow_ + 2 * 8 * pos;
-    for (uint8_t bit = 0x80; bit; bit >>= 1, buffer_pos += 2) {
-        if (data & bit) {   // set
-            buffer_pos->set |= (1 << data_gpio);
-            buffer_pos->clr &= ~(1 << data_gpio);
-        } else {            // reset
-            buffer_pos->set &= ~(1 << data_gpio);
-            buffer_pos->clr |= (1 << data_gpio);
+
+	uint32_t		const pinBit = 1 << pin;
+	uint32_t		const pinNotBit = ~pinBit;
+    GPIOData*		buffer_pos = gpio_shadow_ + 2 * 8 * pos;
+    
+    for (uint8_t bit = 0x80; bit != 0; bit >>= 1)
+    {
+        if (data & bit)
+        {   // set
+            buffer_pos->set |= pinBit;
+            buffer_pos->clr &= pinNotBit;
         }
+        else
+        {            // reset
+            buffer_pos->set &= pinNotBit;
+            buffer_pos->clr |= pinBit;
+        }
+        buffer_pos += 2;
     }
 }
 
@@ -253,7 +263,7 @@ void DMAMultiSPI::SendBuffers() {
 
 
 // Public interface
-MultiSPI *CreateDMAMultiSPI(int clock_gpio) {
-    return new DMAMultiSPI(clock_gpio);
+MultiSPI *CreateDMAMultiSPI(MultiSPI::Pin clockPin) {
+    return new DMAMultiSPI(clockPin);
 }
 }  // namespace spixels

--- a/lib/dma-multi-spi.cc
+++ b/lib/dma-multi-spi.cc
@@ -81,7 +81,9 @@ static void *mmap_bcm_register(off_t register_offset) {
 }
 
 namespace spixels {
+
 namespace {
+
 class DMAMultiSPI : public MultiSPI {
 public:
     explicit DMAMultiSPI(MultiSPI::Pin clockPin);
@@ -199,7 +201,7 @@ void DMAMultiSPI::FinishRegistration() {
         const int n = remaining > kMaxOpsPerBlock ? kMaxOpsPerBlock : remaining;
         cb->info   = (DMA_CB_TI_SRC_INC | DMA_CB_TI_DEST_INC |
                       DMA_CB_TI_NO_WIDE_BURSTS | DMA_CB_TI_TDMODE);
-        cb->src    = (uint32_t)UncachedMemBlock_to_physical(&alloced_, start_gpio);
+        cb->src    = UncachedMemBlock_to_physical(&alloced_, start_gpio);
         cb->dst    = PHYSICAL_GPIO_BUS + GPIO_SET_OFFSET;
         cb->length = DMA_CB_TXFR_LEN_YLENGTH(n)
             | DMA_CB_TXFR_LEN_XLENGTH(sizeof(GPIOData));
@@ -218,14 +220,13 @@ void DMAMultiSPI::FinishRegistration() {
     dma_channel_ = (struct dma_channel_header*)(dmaBase + 0x100 * DMA_CHANNEL);
 }
 
-void DMAMultiSPI::SetBufferedByte(MultiSPI::Pin pin, size_t pos, uint8_t data)
-{
+void DMAMultiSPI::SetBufferedByte(MultiSPI::Pin pin, size_t pos, uint8_t data) {
     assert(pos < serial_byte_size_);
 
-	uint32_t		const pinBit = 1 << pin;
-	uint32_t		const pinNotBit = ~pinBit;
-    GPIOData*		buffer_pos = gpio_shadow_ + 2 * 8 * pos;
-    
+    uint32_t        const pinBit = 1 << pin;
+    uint32_t        const pinNotBit = ~pinBit;
+    GPIOData*       buffer_pos = gpio_shadow_ + 2 * 8 * pos;
+
     for (uint8_t bit = 0x80; bit != 0; bit >>= 1)
     {
         if (data & bit)
@@ -266,4 +267,5 @@ void DMAMultiSPI::SendBuffers() {
 MultiSPI *CreateDMAMultiSPI(MultiSPI::Pin clockPin) {
     return new DMAMultiSPI(clockPin);
 }
+
 }  // namespace spixels

--- a/lib/ft-gpio.cc
+++ b/lib/ft-gpio.cc
@@ -87,7 +87,7 @@ static bool IsRaspberryPi2() {
     if ((mem_size_key = strstr(buffer, "mem_size=")) != NULL
         && (sscanf(mem_size_key + strlen("mem_size="),
                    "%" PRIx64, &mem_size) == 1)
-        && (mem_size == 0x3F000000)) {
+        && (mem_size >= 0x3F000000)) {
         return true;
     }
     return false;

--- a/lib/ft-gpio.cc
+++ b/lib/ft-gpio.cc
@@ -66,7 +66,7 @@ bool GPIO::AddOutput(int bit) {
     }
 
     const uint32_t gpio_mask = 1 << bit;
-    if (bit < 0 || ((gpio_mask & kValidBits) == 0))
+    if ((gpio_mask & kValidBits) == 0)
         return false;
     INP_GPIO(bit);   // for writing, we first need to set as input.
     OUT_GPIO(bit);

--- a/lib/ft-gpio.h
+++ b/lib/ft-gpio.h
@@ -33,31 +33,46 @@ public:
     // Initialize before use. Returns 'true' if successful, 'false' otherwise
     // (e.g. due to a permission problem).
     bool Init();
-    
+
     // Add given gpio pin as output.
     bool AddOutput(int gpio);
 
     // Set the bits that are '1' in the output. Leave the rest untouched.
-    inline void SetBits(uint32_t value) {
-        if (!value) return;
-        *gpio_set_bits_ = value;
+    inline void SetBits(uint32_t bits) {
+        // This test avoids a write that takes a long time.
+        // But direct-multi-spi{} needs this method to take the same amount of time,
+        // no matter what the data is, so don't do it.
+//      if (!bits) return;
+        *gpio_set_bits_ = bits;
     }
 
     // Clear the bits that are '1' in the output. Leave the rest untouched.
-    inline void ClearBits(uint32_t value) {
-        if (!value) return;
-        *gpio_clr_bits_ = value;
+    inline void ClearBits(uint32_t bits) {
+        // This test avoids a write that takes a long time.
+        // But direct-multi-spi{} needs this method to take the same amount of time,
+        // no matter what the data is, so don't do it.
+//      if (!bits) return;
+        *gpio_clr_bits_ = bits;
     }
 
-    // Write only the bits of "value" mentioned in "mask".
-    inline void WriteMaskedBits(uint32_t value, uint32_t mask) {
+    // Write only the bits of "bits" mentioned in "mask".
+    inline void WriteMaskedBits(uint32_t bits, uint32_t mask) {
         // Writing a word is two operations. The IO is actually pretty slow, so
         // this should probably  be unnoticable.
-        ClearBits(~value & mask);
-        SetBits(value & mask);
+        ClearBits(~bits & mask);
+        SetBits(bits & mask);
     }
 
-    inline void Write(uint32_t value) { WriteMaskedBits(value, output_bits_); }
+    inline void Write(uint32_t bits) {
+        ClearBits(~bits & output_bits_);
+        SetBits(bits & output_bits_);
+    }
+    inline void Set(uint32_t bits) {
+        SetBits(bits & output_bits_);
+    }
+    inline void Clear(uint32_t bits) {
+        ClearBits(bits & output_bits_);
+    }
 
 private:
     uint32_t output_bits_;

--- a/lib/led-strip.cc
+++ b/lib/led-strip.cc
@@ -59,8 +59,10 @@ LEDStrip::LEDStrip(int pixelCount)
 /*
     , values_(new RGBc[pixelCount])
 */
-    , brightnessScale16_(0x10000)
 {
+	redScale16_ = 0x10000;
+	greenScale16_ = 0x10000;
+	blueScale16_ = 0x10000;
 }
 
 LEDStrip::~LEDStrip()
@@ -113,26 +115,18 @@ public:
 
     virtual void SetPixel8(uint32_t pixel_index, uint8_t red, uint8_t green, uint8_t blue)
     {
-    	uint32_t		const scale = brightnessScale16_;
-    	
-    	if (scale > 0x10000)
+    	if (pixel_index < (uint32_t)pixelCount_)
     	{
-    		red = (uint8_t)std::min(red * scale / 0x10000, (uint32_t)0xFF);
-    		green = (uint8_t)std::min(green * scale / 0x10000, (uint32_t)0xFF);
-    		blue = (uint8_t)std::min(blue * scale / 0x10000, (uint32_t)0xFF);
-    	}
-    	else if (scale < 0x10000)
-    	{
-    		red = (uint8_t)(red * scale / 0x10000);
-    		green = (uint8_t)(green * scale / 0x10000);
-    		blue = (uint8_t)(blue * scale / 0x10000);
-    	}
+    		red = (uint8_t)std::min(red * redScale16_ / 0x10000, (uint32_t)0xFF);
+    		green = (uint8_t)std::min(green * greenScale16_ / 0x10000, (uint32_t)0xFF);
+    		blue = (uint8_t)std::min(blue * blueScale16_ / 0x10000, (uint32_t)0xFF);
 
-		uint32_t		const offset = WS_start_frame_bytes + WS_pixel_bytes * pixel_index;
+			uint32_t		const offset = WS_start_frame_bytes + WS_pixel_bytes * pixel_index;
 
-        spi_->SetBufferedByte(pin_, offset + 0, red);
-        spi_->SetBufferedByte(pin_, offset + 1, green);
-        spi_->SetBufferedByte(pin_, offset + 2, blue);
+	        spi_->SetBufferedByte(pin_, offset + 0, red);
+	        spi_->SetBufferedByte(pin_, offset + 1, green);
+	        spi_->SetBufferedByte(pin_, offset + 2, blue);
+	    }
     }
 
 private:
@@ -144,9 +138,9 @@ private:
 /////////////////////////////////////////////////
 //#pragma mark - LPD6803LedStrip:
 
-#define LPD_start_frame_bytes	4
-#define LPD_pixel_bytes			2
-#define LPD_end_frame_bytes		4
+#define LPD6803_start_frame_bytes	4
+#define LPD6803_pixel_bytes			2
+#define LPD6803_end_frame_bytes		4
 
 class LPD6803LedStrip : public LEDStrip
 {
@@ -156,7 +150,7 @@ public:
     , spi_(spi)
     , pin_(pin)
     {
-        const size_t frame_bytes = LPD_start_frame_bytes + LPD_pixel_bytes * pixelCount + LPD_end_frame_bytes;
+        const size_t frame_bytes = LPD6803_start_frame_bytes + LPD6803_pixel_bytes * pixelCount + LPD6803_end_frame_bytes;
         
         spi_->RegisterDataGPIO(pin, frame_bytes);
 
@@ -175,32 +169,77 @@ public:
 
     virtual void SetPixel8(uint32_t pixel_index, uint8_t red, uint8_t green, uint8_t blue)
     {
-    	uint32_t		const scale = brightnessScale16_;
-    	
-    	if (scale > 0x10000)
+    	if (pixel_index < (uint32_t)pixelCount_)
     	{
-    		red = (uint8_t)std::min(red * scale / 0x10000, (uint32_t)0xFF);
-    		green = (uint8_t)std::min(green * scale / 0x10000, (uint32_t)0xFF);
-    		blue = (uint8_t)std::min(blue * scale / 0x10000, (uint32_t)0xFF);
-    	}
-    	else if (scale < 0x10000)
-    	{
-    		red = (uint8_t)(red * scale / 0x10000);
-    		green = (uint8_t)(green * scale / 0x10000);
-    		blue = (uint8_t)(blue * scale / 0x10000);
-    	}
-    	
-        uint16_t		data;
-        
-        data = (1<<15);  // start bit
-        data |= (red >> 3) << 10;
-        data |= (green >> 3) <<  5;
-        data |= (blue >> 3) <<  0;
+    		red = (uint8_t)std::min(red * redScale16_ / 0x10000, (uint32_t)0xFF);
+    		green = (uint8_t)std::min(green * greenScale16_ / 0x10000, (uint32_t)0xFF);
+    		blue = (uint8_t)std::min(blue * blueScale16_ / 0x10000, (uint32_t)0xFF);
+	    	
+	        uint16_t		data;
+	        
+	        data = (1<<15);  // start bit
+	        data |= (red >> 3) << 10;
+	        data |= (green >> 3) <<  5;
+	        data |= (blue >> 3) <<  0;
 
-		uint32_t		const offset = LPD_start_frame_bytes + LPD_pixel_bytes * pixel_index;
-		
-        spi_->SetBufferedByte(pin_, offset + 0, data >> 8);
-        spi_->SetBufferedByte(pin_, offset + 1, data & 0xFF);
+			uint32_t		const offset = LPD6803_start_frame_bytes + LPD6803_pixel_bytes * pixel_index;
+			
+	        spi_->SetBufferedByte(pin_, offset + 0, data >> 8);
+	        spi_->SetBufferedByte(pin_, offset + 1, data & 0xFF);
+	    }
+    }
+
+private:
+    MultiSPI*		const spi_;
+    MultiSPI::Pin	const pin_;
+};
+
+
+/////////////////////////////////////////////////
+//#pragma mark - LPD8806LedStrip:
+
+#define LPD8806_start_frame_bytes	1
+#define LPD8806_pixel_bytes			3
+#define LPD8806_end_frame_bytes		0
+
+class LPD8806_LedStrip : public LEDStrip
+{
+public:
+    LPD8806_LedStrip(MultiSPI *spi, MultiSPI::Pin pin, int pixelCount)
+    : LEDStrip(pixelCount)
+    , spi_(spi)
+    , pin_(pin)
+    {
+        const size_t frame_bytes = LPD8806_start_frame_bytes +
+        							LPD8806_pixel_bytes * pixelCount +
+        							LPD8806_end_frame_bytes;
+        
+        spi_->RegisterDataGPIO(pin, frame_bytes);
+
+		// These zeroings shouldn't be required since RegisterDataGPIO() clears all bytes
+		// But until it can be tested, we leave this in.
+        // Four zero bytes as start-bytes for lpd6803
+        spi_->SetBufferedByte(pin_, 0, 0x00);
+        for (int pixel_index = 0; pixel_index < pixelCount; ++pixel_index)
+        {
+            SetPixel8(pixel_index, 0, 0, 0);     // Initialize all top-bits.
+        }
+    }
+
+    virtual void SetPixel8(uint32_t pixel_index, uint8_t red, uint8_t green, uint8_t blue)
+    {
+    	if (pixel_index < (uint32_t)pixelCount_)
+    	{
+			uint32_t		const offset = LPD8806_start_frame_bytes + LPD8806_pixel_bytes * pixel_index;
+
+    		red = (uint8_t)std::min(red * redScale16_ / 0x10000, (uint32_t)0xFF);
+    		green = (uint8_t)std::min(green * greenScale16_ / 0x10000, (uint32_t)0xFF);
+    		blue = (uint8_t)std::min(blue * blueScale16_ / 0x10000, (uint32_t)0xFF);
+	    	
+	        spi_->SetBufferedByte(pin_, offset + 0, (uint8_t)((blue >> 1) | 0x80));
+	        spi_->SetBufferedByte(pin_, offset + 1, (uint8_t)((green >> 1) | 0x80));
+	        spi_->SetBufferedByte(pin_, offset + 2, (uint8_t)((red >> 1) | 0x80));
+	    }
     }
 
 private:
@@ -211,6 +250,14 @@ private:
 
 /////////////////////////////////////////////////
 //#pragma mark - APA102LedStrip:
+
+// The APA102 protocol has an extra byte for each pixel, 5 bits of which control its "global brightness".
+// This value is multipled by each component value to adjust the brightness of the entire pixel.
+// In the APA102, this is implemented by switching to 13-bit PWM.
+// Therefore, it is assumed that brightness dims linearly with "global brightness".
+// SetBrightnessScale16() makes use of this parameter, choosing a 5-bit value to send for every pixel,
+// every frame.  It also stores 32-bit values that are multipled by each component for finer adjustment.
+// When SetPixel16() is called, the global brightness value for each pixel is calculated on the fly.
 
 #define APA_start_frame_bytes	4
 #define APA_pixel_bytes			4
@@ -230,134 +277,280 @@ public:
 
         spi_->RegisterDataGPIO(pin, frame_bytes);
 
-		uint32_t		index;
-		
-		index = 0;
-		hardwareScaleInverseTable8_[0] = 0;
-		while (++index < 32u)
-		{
-			hardwareScaleInverseTable8_[index] = (32u << 8) / index;
-		}
-		componentsScale16_ = 0x10000;
+		componentsRedScale16_ = 0x10000;
+		componentsGreenScale16_ = 0x10000;
+		componentsBlueScale16_ = 0x10000;
 		hardwareBrightnessByte_ = 0x1F;
 
-/*		These zeroings aren't needed since RegisterDataGPIO() zeros all bytes
-        // Four zero bytes as start-bytes
-        spi_->SetBufferedByte(pin_, 0, 0x00);
-        spi_->SetBufferedByte(pin_, 1, 0x00);
-        spi_->SetBufferedByte(pin_, 2, 0x00);
-        spi_->SetBufferedByte(pin_, 3, 0x00);
-
-        // Make sure the start bits are properly set.
-        for (int pixel_index = 0; pixel_index < pixelCount; ++pixel_index)
-        {
-            SetPixel8(pixel_index, 0, 0, 0);
-        }
-
-        // We need a couple of more bits clocked at the end.
-        for (size_t tail = APA_start_frame_bytes + pixels_bytes; tail < frame_bytes; ++tail)
-        {
-            spi_->SetBufferedByte(pin_, tail, 0xff);	// endframe should be 0s, not 1s!
-        }
-*/
-    }
-
-	virtual void SetBrightnessScale16(uint32_t brightnessScale16)
+		if (!hardwareInverseTable8Created_)
+		{
+			uint32_t		hardwareScale5;
+			
+			hardwareScale5 = 0;
+			hardwareInverseTable8_[0] = 0;
+			while (++hardwareScale5 < 32u)
+			{
+				hardwareInverseTable8_[hardwareScale5] = (31u << 8) / hardwareScale5;
+			}
+			hardwareInverseTable8Created_ = true;
+		}
+	}
+	
+	virtual void SetBrightnessScale16(uint32_t redScale16, uint32_t greenScale16, uint32_t blueScale16)
 	{
-		brightnessScale16_ = brightnessScale16;
-		
-    	if (brightnessScale16 < 0x10000)
+		redScale16_ = redScale16;
+		greenScale16_ = greenScale16;
+		blueScale16_ = blueScale16;
+
+		uint32_t		const maxScale = std::max(std::max(redScale16, greenScale16), blueScale16);
+				
+    	if (maxScale < 0x10000)
     	{
     		uint32_t		hardwareScale5;
     		
     		// brightnessScale16 is 0x10000 for no scaling.
-    		// For APA102, we squeeze this range down to 0...32.
-    		// We fudge 32 into 31 so that 50%, 25%, and other common scales have pretty math.
+    		// For APA102, we squeeze this range down to 0...31
     		// We disallow 0 since that would just result in blackness.
-    		hardwareScale5 = brightnessScale16 >> 11;
+    		hardwareScale5 = (maxScale + 0x03FFu) >> 11;
     		hardwareScale5 = std::min(hardwareScale5, 31u);
     		hardwareScale5 = std::max(hardwareScale5, 1u);
     		hardwareBrightnessByte_ = (uint8_t)hardwareScale5 | 0xE0;
     		
     		// componentsScale16_ scales down the compoent values directly.
     		// It provides more precision, in addition to the crude, 5-bit hardware brightness.
-    		componentsScale16_ = brightnessScale16 * 32u / hardwareScale5;
+    		componentsRedScale16_ = redScale16 * 31u / hardwareScale5;
+    		componentsGreenScale16_ = greenScale16 * 31u / hardwareScale5;
+    		componentsBlueScale16_ = blueScale16 * 31u / hardwareScale5;
     	}
     	else
     	{
     		// If scaling up or not scaling, don't use any hardware scaling.
     		// Just let componentsScale16_ do it.
     		hardwareBrightnessByte_ = 0xFF;
-    		componentsScale16_ = brightnessScale16;
+    		componentsRedScale16_ = redScale16;
+    		componentsGreenScale16_ = greenScale16;
+    		componentsBlueScale16_ = blueScale16;
     	}
-//		fprintf(stderr, "SetBrightnessScale16() - hardware=0x%02X, components=0x%04X\n",
-//				hardwareBrightnessByte_ & 0x1F, componentsScale16_);
+
+//		fprintf(stderr, "APA102LedStrip::SetBrightnessScale16() - input=0x%04X, hardware=0x%02X, red=0x%04X, green=0x%04X, blue=0x%04X\n",
+//				maxScale, hardwareBrightnessByte_,
+//				componentsRedScale16_, componentsGreenScale16_, componentsBlueScale16_);
 	}
 	
     virtual void SetPixel8(uint32_t pixel_index, uint8_t red, uint8_t green, uint8_t blue)
     {
-    	uint32_t		const scale = componentsScale16_;
-    	
-    	if (scale > 0x10000)
+    	if (pixel_index < (uint32_t)pixelCount_)
     	{
-    		red = (uint8_t)std::min(red * scale / 0x10000, 0xFFu);
-    		green = (uint8_t)std::min(green * scale / 0x10000, 0xFFu);
-    		blue = (uint8_t)std::min(blue * scale / 0x10000, 0xFFu);
-    	}
-    	else if (scale < 0x10000)
-    	{
-    		red = (uint8_t)(red * scale / 0x10000);
-    		green = (uint8_t)(green * scale / 0x10000);
-    		blue = (uint8_t)(blue * scale / 0x10000);
-    	}
+    		red = (uint8_t)std::min(red * componentsRedScale16_ / 0x10000u, 0xFFu);
+    		green = (uint8_t)std::min(green * componentsGreenScale16_ / 0x10000u, 0xFFu);
+    		blue = (uint8_t)std::min(blue * componentsBlueScale16_ / 0x10000u, 0xFFu);
 
-        int				const offset = APA_start_frame_bytes + APA_pixel_bytes * pixel_index;
+	        int				const offset = APA_start_frame_bytes + APA_pixel_bytes * pixel_index;
 
-		spi_->SetBufferedByte(pin_, offset + 0, hardwareBrightnessByte_);
-        spi_->SetBufferedByte(pin_, offset + 1, blue);
-        spi_->SetBufferedByte(pin_, offset + 2, green);
-        spi_->SetBufferedByte(pin_, offset + 3, red);
+			spi_->SetBufferedByte(pin_, offset + 0, hardwareBrightnessByte_);
+	        spi_->SetBufferedByte(pin_, offset + 1, blue);
+	        spi_->SetBufferedByte(pin_, offset + 2, green);
+	        spi_->SetBufferedByte(pin_, offset + 3, red);
+	    }
     }
+
     virtual void SetPixel16(uint32_t pixel_index, uint16_t red, uint16_t green, uint16_t blue)
     {
-    	uint32_t		const scale = brightnessScale16_;
-
-    	if (scale > 0x10000)
+    	if (pixel_index < (uint32_t)pixelCount_)
     	{
-    		red = (uint16_t)std::min(red * scale / 0x10000, 0xFFFFu);
-    		green = (uint16_t)std::min(green * scale / 0x10000, 0xFFFFu);
-    		blue = (uint16_t)std::min(blue * scale / 0x10000, 0xFFFFu);
-    	}
-    	else if (scale < 0x10000)
-    	{
-    		red = (uint16_t)(red * scale / 0x10000);
-    		green = (uint16_t)(green * scale / 0x10000);
-    		blue = (uint16_t)(blue * scale / 0x10000);
-    	}
+			red = (uint16_t)std::min((uint32_t)((uint64_t)red * redScale16_ / 0x10000), (uint32_t)0xFFFFu);
+			green = (uint16_t)std::min((uint32_t)((uint64_t)green * greenScale16_ / 0x10000), (uint32_t)0xFFFFu);
+			blue = (uint16_t)std::min((uint32_t)((uint64_t)blue * blueScale16_ / 0x10000), (uint32_t)0xFFFFu);
 
-		uint32_t		const maxHigh5Bits = std::max(std::max(red, green), blue) >> 11;
-		uint32_t		const hardwareScale = std::min(maxHigh5Bits + 1u, 31u);
-		uint32_t		const inverse8 = hardwareScaleInverseTable8_[hardwareScale];
-		
-		red = (uint16_t)(red * inverse8 / 0x10000);
-		green = (uint16_t)(green * inverse8 / 0x10000);
-		blue = (uint16_t)(blue * inverse8 / 0x10000);
-		
-        int				const offset = APA_start_frame_bytes + APA_pixel_bytes * pixel_index;
+			uint32_t		const maxComponent = std::max(std::max(red, green), blue);
+			uint32_t		const high5Bits = (maxComponent + 1 + 0x03FF) >> 11;
+			uint32_t		const hardwareScale5 = std::max(std::min(high5Bits, 31u), 1u);
+			uint32_t		const hardwareInverse8 = hardwareInverseTable8_[hardwareScale5];
+			
+			red = (uint16_t)std::min(red * hardwareInverse8 / 0x10000, 0xFFu);
+			green = (uint16_t)std::min(green * hardwareInverse8 / 0x10000, 0xFFu);
+			blue = (uint16_t)std::min(blue * hardwareInverse8 / 0x10000, 0xFFu);
+			
+			int				const offset = APA_start_frame_bytes + APA_pixel_bytes * pixel_index;
 
-		spi_->SetBufferedByte(pin_, offset + 0, (uint8_t)(0xE0 | hardwareScale));
-        spi_->SetBufferedByte(pin_, offset + 1, (uint8_t)blue);
-        spi_->SetBufferedByte(pin_, offset + 2, (uint8_t)green);
-        spi_->SetBufferedByte(pin_, offset + 3, (uint8_t)red);
+			spi_->SetBufferedByte(pin_, offset + 0, (uint8_t)(0xE0 | hardwareScale5));
+			spi_->SetBufferedByte(pin_, offset + 1, (uint8_t)blue);
+			spi_->SetBufferedByte(pin_, offset + 2, (uint8_t)green);
+			spi_->SetBufferedByte(pin_, offset + 3, (uint8_t)red);
+		}
     }
 
 private:
     MultiSPI*		const spi_;
     MultiSPI::Pin	const pin_;
-    uint32_t		componentsScale16_;					// scales component values before sending to spi_
+    uint32_t		componentsRedScale16_;				// scales component values before sending to spi_
+    uint32_t		componentsGreenScale16_;			// scales component values before sending to spi_
+    uint32_t		componentsBlueScale16_;				// scales component values before sending to spi_
     uint8_t			hardwareBrightnessByte_;			// byte sent to APA102 when SetPixel8() used
-   	uint32_t		hardwareScaleInverseTable8_[32];	// used by SetPixel16() to quickly divide
+
+static bool			hardwareInverseTable8Created_;
+static uint32_t		hardwareInverseTable8_[32];	// used by SetPixel16() to quickly divide
 };
+
+bool			APA102LedStrip::hardwareInverseTable8Created_ = false;
+uint32_t		APA102LedStrip::hardwareInverseTable8_[32];
+
+
+/////////////////////////////////////////////////
+//#pragma mark - SK9822LedStrip:
+
+// APA102 and SK9822 strips have the same protocol, but they implement
+// "global brightness" differently.
+// APA102 uses 13-bit PWM to implement global brightness.  This is assumed
+// to be linear.
+// SK9822 uses a variable current driver, which is inherently nonlinear.
+// When pixels are dimmed with global brightness, they appear brighter than they
+// do in an APA102 chip.  Also, pixels appear to get more blue/green as they
+// are dimmed this way.
+// Therefore, SK9822LedStrip{} has separate "hardware inverse" tables for red, green, and blue.
+// They are created slightly differently, to adjust color as lower and lower global brightness
+// values are used.  When no hardware dimmings is used, they don't scale components at all.
+
+class SK9822LedStrip : public LEDStrip
+{
+public:
+    SK9822LedStrip(MultiSPI *spi, MultiSPI::Pin pin, int pixelCount)
+	: LEDStrip(pixelCount)
+	, spi_(spi)
+	, pin_(pin)
+	{
+        const size_t pixels_bytes = APA_pixel_bytes * pixelCount;
+        const size_t end_frame_bytes = APA_latch_frame_bytes + (pixelCount + 15) / 16;
+        const size_t frame_bytes = APA_start_frame_bytes + pixels_bytes + end_frame_bytes;
+
+        spi_->RegisterDataGPIO(pin, frame_bytes);
+
+		componentsRedScale16_ = 0x10000;
+		componentsGreenScale16_ = 0x10000;
+		componentsBlueScale16_ = 0x10000;
+		hardwareBrightnessByte_ = 0x1F;
+
+		if (!hardwareInverseTablesCreated_)
+		{
+			uint32_t		hardwareScale5;
+			
+			hardwareScale5 = 0;
+			hardwareRedInverseTable8_[0] = 0;
+			hardwareGreenInverseTable8_[0] = 0;
+			hardwareBlueInverseTable8_[0] = 0;
+			while (++hardwareScale5 < 32u)
+			{
+				hardwareRedInverseTable8_[hardwareScale5] = (31u * 0xF0) / hardwareScale5 + (0x100 - 0xF0);
+				hardwareGreenInverseTable8_[hardwareScale5] = (31u * 0x80) / hardwareScale5 + (0x100 - 0x80);
+				hardwareBlueInverseTable8_[hardwareScale5] = (31u * 0x80) / hardwareScale5 + (0x100 - 0x80);
+			}
+			hardwareInverseTablesCreated_ = true;
+		}
+    }
+
+	virtual void SetBrightnessScale16(uint32_t redScale16, uint32_t greenScale16, uint32_t blueScale16)
+	{
+		redScale16_ = redScale16;
+		greenScale16_ = greenScale16;
+		blueScale16_ = blueScale16;
+
+		uint32_t		const maxScale = std::max(std::max(redScale16, greenScale16), blueScale16);
+				
+    	if (maxScale < 0x10000)
+    	{
+    		uint32_t		hardwareScale5;
+    		
+    		// brightnessScale16 is 0x10000 for no scaling.
+    		// For APA102, we squeeze this range down to 0...31
+    		// We disallow 0 since that would just result in blackness.
+    		hardwareScale5 = (maxScale + 0x03FFu) >> 11;
+    		hardwareScale5 = std::min(hardwareScale5, 31u);
+    		hardwareScale5 = std::max(hardwareScale5, 1u);
+    		hardwareBrightnessByte_ = (uint8_t)hardwareScale5 | 0xE0;
+    		
+    		// componentsScale16_ scales down the compoent values directly.
+    		// It provides more precision, in addition to the crude, 5-bit hardware brightness.
+    		componentsRedScale16_ = redScale16 * hardwareRedInverseTable8_[hardwareScale5] / 0x100;
+    		componentsGreenScale16_ = greenScale16 * hardwareGreenInverseTable8_[hardwareScale5] / 0x100;
+    		componentsBlueScale16_ = blueScale16 * hardwareBlueInverseTable8_[hardwareScale5] / 0x100;
+    	}
+    	else
+    	{
+    		// If scaling up or not scaling, don't use any hardware scaling.
+    		// Just let componentsScale16_ do it.
+    		hardwareBrightnessByte_ = 0xFF;
+    		componentsRedScale16_ = redScale16;
+    		componentsGreenScale16_ = greenScale16;
+    		componentsBlueScale16_ = blueScale16;
+    	}
+
+//		fprintf(stderr, "SK9822LedStrip::SetBrightnessScale16() - input=0x%04X, hardware=0x%02X, red=0x%04X, green=0x%04X, blue=0x%04X\n",
+//				maxScale, hardwareBrightnessByte_ & 0x1F,
+//				componentsRedScale16_, componentsGreenScale16_, componentsBlueScale16_);
+	}
+	
+    virtual void SetPixel8(uint32_t pixel_index, uint8_t red, uint8_t green, uint8_t blue)
+    {
+    	if (pixel_index < (uint32_t)pixelCount_)
+    	{
+    		red = (uint8_t)std::min(red * componentsRedScale16_ / 0x10000u, 0xFFu);
+    		green = (uint8_t)std::min(green * componentsGreenScale16_ / 0x10000u, 0xFFu);
+    		blue = (uint8_t)std::min(blue * componentsBlueScale16_ / 0x10000u, 0xFFu);
+
+	        int				const offset = APA_start_frame_bytes + APA_pixel_bytes * pixel_index;
+
+			spi_->SetBufferedByte(pin_, offset + 0, hardwareBrightnessByte_);
+	        spi_->SetBufferedByte(pin_, offset + 1, blue);
+	        spi_->SetBufferedByte(pin_, offset + 2, green);
+	        spi_->SetBufferedByte(pin_, offset + 3, red);
+	    }
+    }
+    
+    virtual void SetPixel16(uint32_t pixel_index, uint16_t red, uint16_t green, uint16_t blue)
+    {
+    	if (pixel_index < (uint32_t)pixelCount_)
+    	{
+			red = (uint16_t)std::min((uint32_t)((uint64_t)red * redScale16_ / 0x10000), (uint32_t)0xFFFFu);
+			green = (uint16_t)std::min((uint32_t)((uint64_t)green * greenScale16_ / 0x10000), (uint32_t)0xFFFFu);
+			blue = (uint16_t)std::min((uint32_t)((uint64_t)blue * blueScale16_ / 0x10000), (uint32_t)0xFFFFu);
+
+			uint32_t		const maxComponent = std::max(std::max(red, green), blue);
+			uint32_t		const high5Bits = (maxComponent + 1 + 0x03FF) >> 11;
+			uint32_t		const hardwareScale5 = std::max(std::min(high5Bits, 31u), 1u);
+			
+			red = (uint16_t)std::min(red * hardwareRedInverseTable8_[hardwareScale5] / 0x10000, 0xFFu);
+			green = (uint16_t)std::min(green * hardwareGreenInverseTable8_[hardwareScale5] / 0x10000, 0xFFu);
+			blue = (uint16_t)std::min(blue * hardwareBlueInverseTable8_[hardwareScale5] / 0x10000, 0xFFu);
+			
+			int				const offset = APA_start_frame_bytes + APA_pixel_bytes * pixel_index;
+
+			spi_->SetBufferedByte(pin_, offset + 0, (uint8_t)(0xE0 | hardwareScale5));
+			spi_->SetBufferedByte(pin_, offset + 1, (uint8_t)blue);
+			spi_->SetBufferedByte(pin_, offset + 2, (uint8_t)green);
+			spi_->SetBufferedByte(pin_, offset + 3, (uint8_t)red);
+		}
+    }
+
+protected:
+    MultiSPI*		const spi_;
+    MultiSPI::Pin	const pin_;
+    
+private:
+    uint32_t		componentsRedScale16_;				// scales component values before sending to spi_
+    uint32_t		componentsGreenScale16_;			// scales component values before sending to spi_
+    uint32_t		componentsBlueScale16_;				// scales component values before sending to spi_
+    uint8_t			hardwareBrightnessByte_;			// byte sent to APA102 when SetPixel8() used
+
+static bool			hardwareInverseTablesCreated_;
+static uint32_t		hardwareRedInverseTable8_[32];		// used by SetPixel16() to quickly divide
+static uint32_t		hardwareGreenInverseTable8_[32];	// used by SetPixel16() to quickly divide
+static uint32_t		hardwareBlueInverseTable8_[32];		// used by SetPixel16() to quickly divide
+};
+
+bool			SK9822LedStrip::hardwareInverseTablesCreated_ = false;
+uint32_t		SK9822LedStrip::hardwareRedInverseTable8_[32];
+uint32_t		SK9822LedStrip::hardwareGreenInverseTable8_[32];
+uint32_t		SK9822LedStrip::hardwareBlueInverseTable8_[32];
 
 
 }  // anonymous namespace
@@ -370,8 +563,14 @@ LEDStrip *CreateWS2801Strip(MultiSPI *spi, MultiSPI::Pin pin, int pixelCount) {
 LEDStrip *CreateLPD6803Strip(MultiSPI *spi, MultiSPI::Pin pin, int pixelCount) {
     return new LPD6803LedStrip(spi, pin, pixelCount);
 }
+LEDStrip *CreateLPD8806Strip(MultiSPI *spi, MultiSPI::Pin pin, int pixelCount) {
+    return new LPD8806_LedStrip(spi, pin, pixelCount);
+}
 LEDStrip *CreateAPA102Strip(MultiSPI *spi, MultiSPI::Pin pin, int pixelCount) {
     return new APA102LedStrip(spi, pin, pixelCount);
+}
+LEDStrip *CreateSK9822Strip(MultiSPI *spi, MultiSPI::Pin pin, int pixelCount) {
+    return new SK9822LedStrip(spi, pin, pixelCount);
 }
 
 

--- a/lib/led-strip.cc
+++ b/lib/led-strip.cc
@@ -22,72 +22,20 @@
 #include "multi-spi.h"
 #include "led-strip.h"
 
-#define DO_CIE1931		FALSE
-
-
-/*
-typedef uint16_t CIEValue;
-
-// Do CIE1931 luminance correction and scale to maximum expected output bits.
-static CIEValue luminance_cie1931_internal(uint8_t c, uint8_t brightness) {
-    const float out_factor = 0xFFFF;
-    const float v = 100.0f * (brightness/255.0f) * (c/255.0f);
-    return out_factor * ((v <= 8) ? v / 902.3 : pow((v + 16) / 116.0, 3));
-}
-
-static CIEValue *CreateCIE1931LookupTable() {
-    CIEValue *result = new CIEValue[256 * 256];
-    for (int v = 0; v < 256; ++v) {      // Value
-        for (int b = 0; b < 256; ++b) {  // Brightness
-            result[b * 256 + v] = luminance_cie1931_internal(v, b);
-        }
-    }
-    return result;
-}
-
-// Return a CIE1931 corrected value from given desired lumninace value and
-// brightness.
-static CIEValue luminance_cie1931(uint8_t value, uint8_t bright) {
-    static const CIEValue *const luminance_lookup = CreateCIE1931LookupTable();
-    return luminance_lookup[bright * 256 + value];
-}
-*/
 
 namespace spixels {
+
+
 LEDStrip::LEDStrip(int pixelCount)
-    : pixelCount_(pixelCount)
-/*
-    , values_(new RGBc[pixelCount])
-*/
-{
-	redScale16_ = 0x10000;
-	greenScale16_ = 0x10000;
-	blueScale16_ = 0x10000;
-}
+: pixelCount_(pixelCount) {
+    redScale_ = 1.0f;
+    greenScale_ = 1.0f;
+    blueScale_ = 1.0f;
 
-LEDStrip::~LEDStrip()
-{
-//	delete values_;
+    redScale16_ = 0x10000;
+    greenScale16_ = 0x10000;
+    blueScale16_ = 0x10000;
 }
-
-/*
-void LEDStrip::SetPixel(int pos, const RGBc& c) {
-    if (pos < 0 || pos >= pixelCount()) return;
-    values_[pos] = c;
-    SetLinearValues(pos,
-                    luminance_cie1931(c.r, brightness_),
-                    luminance_cie1931(c.g, brightness_),
-                    luminance_cie1931(c.b, brightness_));
-}
-
-void LEDStrip::SetBrightness(uint8_t new_brightness) {
-    if (new_brightness == brightness_) return;
-    brightness_ = new_brightness;
-    for (int i = 0; i < pixelCount_; ++i) {
-        SetPixel(i, values_[i]);  // Force recalculation.
-    }
-}
-*/
 
 
 namespace {
@@ -96,155 +44,135 @@ namespace {
 /////////////////////////////////////////////////
 //#pragma mark - WS2801LedStrip:
 
-#define WS_start_frame_bytes	0
-#define WS_pixel_bytes			3
-#define WS_end_frame_bytes		0
+#define WS_start_frame_bytes    0
+#define WS_pixel_bytes          3
+#define WS_end_frame_bytes      0
 
-class WS2801LedStrip : public LEDStrip
-{
+class WS2801LedStrip : public LEDStrip {
 public:
     WS2801LedStrip(MultiSPI *spi, MultiSPI::Pin pin, int pixelCount)
-    : LEDStrip(pixelCount)
-    , spi_(spi)
-    , pin_(pin)
-    {
+    : LEDStrip(pixelCount), spi_(spi), pin_(pin) {
         const size_t frame_bytes = WS_start_frame_bytes + WS_pixel_bytes * pixelCount + WS_end_frame_bytes;
-        
+
         spi_->RegisterDataGPIO(pin, frame_bytes);
     }
 
-    virtual void SetPixel8(uint32_t pixel_index, uint8_t red, uint8_t green, uint8_t blue)
-    {
-    	if (pixel_index < (uint32_t)pixelCount_)
-    	{
-    		red = (uint8_t)std::min(red * redScale16_ / 0x10000, (uint32_t)0xFF);
-    		green = (uint8_t)std::min(green * greenScale16_ / 0x10000, (uint32_t)0xFF);
-    		blue = (uint8_t)std::min(blue * blueScale16_ / 0x10000, (uint32_t)0xFF);
+    virtual void SetPixel8(uint32_t pixel_index, uint8_t red, uint8_t green, uint8_t blue) {
+        if (pixel_index < (uint32_t)pixelCount_) {
+            red = (uint8_t)std::min(red * redScale16_ / 0x10000, (uint32_t)0xFF);
+            green = (uint8_t)std::min(green * greenScale16_ / 0x10000, (uint32_t)0xFF);
+            blue = (uint8_t)std::min(blue * blueScale16_ / 0x10000, (uint32_t)0xFF);
 
-			uint32_t		const offset = WS_start_frame_bytes + WS_pixel_bytes * pixel_index;
+            uint32_t        const offset = WS_start_frame_bytes + WS_pixel_bytes * pixel_index;
 
-	        spi_->SetBufferedByte(pin_, offset + 0, red);
-	        spi_->SetBufferedByte(pin_, offset + 1, green);
-	        spi_->SetBufferedByte(pin_, offset + 2, blue);
-	    }
+            spi_->SetBufferedByte(pin_, offset + 0, red);
+            spi_->SetBufferedByte(pin_, offset + 1, green);
+            spi_->SetBufferedByte(pin_, offset + 2, blue);
+        }
     }
 
 private:
-    MultiSPI*		const spi_;
-    MultiSPI::Pin	const pin_;
+    MultiSPI*       const spi_;
+    MultiSPI::Pin   const pin_;
 };
 
 
 /////////////////////////////////////////////////
 //#pragma mark - LPD6803LedStrip:
 
-#define LPD6803_start_frame_bytes	4
-#define LPD6803_pixel_bytes			2
-#define LPD6803_end_frame_bytes		4
+#define LPD6803_start_frame_bytes   4
+#define LPD6803_pixel_bytes         2
+#define LPD6803_end_frame_bytes     4
 
-class LPD6803LedStrip : public LEDStrip
-{
+class LPD6803LedStrip : public LEDStrip {
 public:
     LPD6803LedStrip(MultiSPI *spi, MultiSPI::Pin pin, int pixelCount)
-    : LEDStrip(pixelCount)
-    , spi_(spi)
-    , pin_(pin)
-    {
+    : LEDStrip(pixelCount), spi_(spi), pin_(pin) {
         const size_t frame_bytes = LPD6803_start_frame_bytes + LPD6803_pixel_bytes * pixelCount + LPD6803_end_frame_bytes;
-        
+
         spi_->RegisterDataGPIO(pin, frame_bytes);
 
-		// These zeroings shouldn't be required since RegisterDataGPIO() clears all bytes
-		// But until it can be tested, we leave this in.
+        // These zeroings shouldn't be required since RegisterDataGPIO() clears all bytes
+        // But until it can be tested, we leave this in.
         // Four zero bytes as start-bytes for lpd6803
         spi_->SetBufferedByte(pin_, 0, 0x00);
         spi_->SetBufferedByte(pin_, 1, 0x00);
         spi_->SetBufferedByte(pin_, 2, 0x00);
         spi_->SetBufferedByte(pin_, 3, 0x00);
-        for (int pixel_index = 0; pixel_index < pixelCount; ++pixel_index)
-        {
+        for (int pixel_index = 0; pixel_index < pixelCount; ++pixel_index) {
             SetPixel8(pixel_index, 0, 0, 0);     // Initialize all top-bits.
         }
     }
 
-    virtual void SetPixel8(uint32_t pixel_index, uint8_t red, uint8_t green, uint8_t blue)
-    {
-    	if (pixel_index < (uint32_t)pixelCount_)
-    	{
-    		red = (uint8_t)std::min(red * redScale16_ / 0x10000, (uint32_t)0xFF);
-    		green = (uint8_t)std::min(green * greenScale16_ / 0x10000, (uint32_t)0xFF);
-    		blue = (uint8_t)std::min(blue * blueScale16_ / 0x10000, (uint32_t)0xFF);
-	    	
-	        uint16_t		data;
-	        
-	        data = (1<<15);  // start bit
-	        data |= (red >> 3) << 10;
-	        data |= (green >> 3) <<  5;
-	        data |= (blue >> 3) <<  0;
+    virtual void SetPixel8(uint32_t pixel_index, uint8_t red, uint8_t green, uint8_t blue) {
+        if (pixel_index < (uint32_t)pixelCount_) {
+            red = (uint8_t)std::min(red * redScale16_ / 0x10000, (uint32_t)0xFF);
+            green = (uint8_t)std::min(green * greenScale16_ / 0x10000, (uint32_t)0xFF);
+            blue = (uint8_t)std::min(blue * blueScale16_ / 0x10000, (uint32_t)0xFF);
 
-			uint32_t		const offset = LPD6803_start_frame_bytes + LPD6803_pixel_bytes * pixel_index;
-			
-	        spi_->SetBufferedByte(pin_, offset + 0, data >> 8);
-	        spi_->SetBufferedByte(pin_, offset + 1, data & 0xFF);
-	    }
+            uint16_t        data;
+
+            data = (1<<15);  // start bit
+            data |= (red >> 3) << 10;
+            data |= (green >> 3) <<  5;
+            data |= (blue >> 3) <<  0;
+
+            uint32_t        const offset = LPD6803_start_frame_bytes + LPD6803_pixel_bytes * pixel_index;
+
+            spi_->SetBufferedByte(pin_, offset + 0, data >> 8);
+            spi_->SetBufferedByte(pin_, offset + 1, data & 0xFF);
+        }
     }
 
 private:
-    MultiSPI*		const spi_;
-    MultiSPI::Pin	const pin_;
+    MultiSPI*       const spi_;
+    MultiSPI::Pin   const pin_;
 };
 
 
 /////////////////////////////////////////////////
 //#pragma mark - LPD8806LedStrip:
 
-#define LPD8806_start_frame_bytes	1
-#define LPD8806_pixel_bytes			3
-#define LPD8806_end_frame_bytes		0
+#define LPD8806_start_frame_bytes   1
+#define LPD8806_pixel_bytes         3
+#define LPD8806_end_frame_bytes     0
 
-class LPD8806_LedStrip : public LEDStrip
-{
+class LPD8806_LedStrip : public LEDStrip {
 public:
     LPD8806_LedStrip(MultiSPI *spi, MultiSPI::Pin pin, int pixelCount)
-    : LEDStrip(pixelCount)
-    , spi_(spi)
-    , pin_(pin)
-    {
+    : LEDStrip(pixelCount), spi_(spi), pin_(pin) {
         const size_t frame_bytes = LPD8806_start_frame_bytes +
-        							LPD8806_pixel_bytes * pixelCount +
-        							LPD8806_end_frame_bytes;
-        
+                                    LPD8806_pixel_bytes * pixelCount +
+                                    LPD8806_end_frame_bytes;
+
         spi_->RegisterDataGPIO(pin, frame_bytes);
 
-		// These zeroings shouldn't be required since RegisterDataGPIO() clears all bytes
-		// But until it can be tested, we leave this in.
+        // These zeroings shouldn't be required since RegisterDataGPIO() clears all bytes
+        // But until it can be tested, we leave this in.
         // Four zero bytes as start-bytes for lpd6803
         spi_->SetBufferedByte(pin_, 0, 0x00);
-        for (int pixel_index = 0; pixel_index < pixelCount; ++pixel_index)
-        {
+        for (int pixel_index = 0; pixel_index < pixelCount; ++pixel_index) {
             SetPixel8(pixel_index, 0, 0, 0);     // Initialize all top-bits.
         }
     }
 
-    virtual void SetPixel8(uint32_t pixel_index, uint8_t red, uint8_t green, uint8_t blue)
-    {
-    	if (pixel_index < (uint32_t)pixelCount_)
-    	{
-			uint32_t		const offset = LPD8806_start_frame_bytes + LPD8806_pixel_bytes * pixel_index;
+    virtual void SetPixel8(uint32_t pixel_index, uint8_t red, uint8_t green, uint8_t blue) {
+        if (pixel_index < (uint32_t)pixelCount_) {
+            uint32_t        const offset = LPD8806_start_frame_bytes + LPD8806_pixel_bytes * pixel_index;
 
-    		red = (uint8_t)std::min(red * redScale16_ / 0x10000, (uint32_t)0xFF);
-    		green = (uint8_t)std::min(green * greenScale16_ / 0x10000, (uint32_t)0xFF);
-    		blue = (uint8_t)std::min(blue * blueScale16_ / 0x10000, (uint32_t)0xFF);
-	    	
-	        spi_->SetBufferedByte(pin_, offset + 0, (uint8_t)((blue >> 1) | 0x80));
-	        spi_->SetBufferedByte(pin_, offset + 1, (uint8_t)((green >> 1) | 0x80));
-	        spi_->SetBufferedByte(pin_, offset + 2, (uint8_t)((red >> 1) | 0x80));
-	    }
+            red = (uint8_t)std::min(red * redScale16_ / 0x10000, (uint32_t)0xFF);
+            green = (uint8_t)std::min(green * greenScale16_ / 0x10000, (uint32_t)0xFF);
+            blue = (uint8_t)std::min(blue * blueScale16_ / 0x10000, (uint32_t)0xFF);
+
+            spi_->SetBufferedByte(pin_, offset + 0, (uint8_t)((blue >> 1) | 0x80));
+            spi_->SetBufferedByte(pin_, offset + 1, (uint8_t)((green >> 1) | 0x80));
+            spi_->SetBufferedByte(pin_, offset + 2, (uint8_t)((red >> 1) | 0x80));
+        }
     }
 
 private:
-    MultiSPI*		const spi_;
-    MultiSPI::Pin	const pin_;
+    MultiSPI*       const spi_;
+    MultiSPI::Pin   const pin_;
 };
 
 
@@ -255,145 +183,129 @@ private:
 // This value is multipled by each component value to adjust the brightness of the entire pixel.
 // In the APA102, this is implemented by switching to 13-bit PWM.
 // Therefore, it is assumed that brightness dims linearly with "global brightness".
-// SetBrightnessScale16() makes use of this parameter, choosing a 5-bit value to send for every pixel,
+// SetBrightnessScale() makes use of this parameter, choosing a 5-bit value to send for every pixel,
 // every frame.  It also stores 32-bit values that are multipled by each component for finer adjustment.
 // When SetPixel16() is called, the global brightness value for each pixel is calculated on the fly.
 
-#define APA_start_frame_bytes	4
-#define APA_pixel_bytes			4
-#define APA_latch_frame_bytes	4	// extra end-frame bytes for compatibility with SK9822 chips
+#define APA_start_frame_bytes   4
+#define APA_pixel_bytes         4
+#define APA_latch_frame_bytes   4   // extra end-frame bytes for compatibility with SK9822 chips
 
-class APA102LedStrip : public LEDStrip
-{
+class APA102LedStrip : public LEDStrip {
 public:
     APA102LedStrip(MultiSPI *spi, MultiSPI::Pin pin, int pixelCount)
-	: LEDStrip(pixelCount)
-	, spi_(spi)
-	, pin_(pin)
-	{
+    : LEDStrip(pixelCount), spi_(spi), pin_(pin) {
         const size_t pixels_bytes = APA_pixel_bytes * pixelCount;
         const size_t end_frame_bytes = APA_latch_frame_bytes + (pixelCount + 15) / 16;
         const size_t frame_bytes = APA_start_frame_bytes + pixels_bytes + end_frame_bytes;
 
         spi_->RegisterDataGPIO(pin, frame_bytes);
 
-		componentsRedScale16_ = 0x10000;
-		componentsGreenScale16_ = 0x10000;
-		componentsBlueScale16_ = 0x10000;
-		hardwareBrightnessByte_ = 0x1F;
+        componentsRedScale16_ = 0x10000;
+        componentsGreenScale16_ = 0x10000;
+        componentsBlueScale16_ = 0x10000;
+        hardwareBrightnessByte_ = 0x1F;
 
-		if (!hardwareInverseTable8Created_)
-		{
-			uint32_t		hardwareScale5;
-			
-			hardwareScale5 = 0;
-			hardwareInverseTable8_[0] = 0;
-			while (++hardwareScale5 < 32u)
-			{
-				hardwareInverseTable8_[hardwareScale5] = (31u << 8) / hardwareScale5;
-			}
-			hardwareInverseTable8Created_ = true;
-		}
-	}
-	
-	virtual void SetBrightnessScale16(uint32_t redScale16, uint32_t greenScale16, uint32_t blueScale16)
-	{
-		redScale16_ = redScale16;
-		greenScale16_ = greenScale16;
-		blueScale16_ = blueScale16;
+        if (!hardwareInverseTable8Created_) {
+            uint32_t        hardwareScale5;
 
-		uint32_t		const maxScale = std::max(std::max(redScale16, greenScale16), blueScale16);
-				
-    	if (maxScale < 0x10000)
-    	{
-    		uint32_t		hardwareScale5;
-    		
-    		// brightnessScale16 is 0x10000 for no scaling.
-    		// For APA102, we squeeze this range down to 0...31
-    		// We disallow 0 since that would just result in blackness.
-    		hardwareScale5 = (maxScale + 0x03FFu) >> 11;
-    		hardwareScale5 = std::min(hardwareScale5, 31u);
-    		hardwareScale5 = std::max(hardwareScale5, 1u);
-    		hardwareBrightnessByte_ = (uint8_t)hardwareScale5 | 0xE0;
-    		
-    		// componentsScale16_ scales down the compoent values directly.
-    		// It provides more precision, in addition to the crude, 5-bit hardware brightness.
-    		componentsRedScale16_ = redScale16 * 31u / hardwareScale5;
-    		componentsGreenScale16_ = greenScale16 * 31u / hardwareScale5;
-    		componentsBlueScale16_ = blueScale16 * 31u / hardwareScale5;
-    	}
-    	else
-    	{
-    		// If scaling up or not scaling, don't use any hardware scaling.
-    		// Just let componentsScale16_ do it.
-    		hardwareBrightnessByte_ = 0xFF;
-    		componentsRedScale16_ = redScale16;
-    		componentsGreenScale16_ = greenScale16;
-    		componentsBlueScale16_ = blueScale16;
-    	}
-
-//		fprintf(stderr, "APA102LedStrip::SetBrightnessScale16() - input=0x%04X, hardware=0x%02X, red=0x%04X, green=0x%04X, blue=0x%04X\n",
-//				maxScale, hardwareBrightnessByte_,
-//				componentsRedScale16_, componentsGreenScale16_, componentsBlueScale16_);
-	}
-	
-    virtual void SetPixel8(uint32_t pixel_index, uint8_t red, uint8_t green, uint8_t blue)
-    {
-    	if (pixel_index < (uint32_t)pixelCount_)
-    	{
-    		red = (uint8_t)std::min(red * componentsRedScale16_ / 0x10000u, 0xFFu);
-    		green = (uint8_t)std::min(green * componentsGreenScale16_ / 0x10000u, 0xFFu);
-    		blue = (uint8_t)std::min(blue * componentsBlueScale16_ / 0x10000u, 0xFFu);
-
-	        int				const offset = APA_start_frame_bytes + APA_pixel_bytes * pixel_index;
-
-			spi_->SetBufferedByte(pin_, offset + 0, hardwareBrightnessByte_);
-	        spi_->SetBufferedByte(pin_, offset + 1, blue);
-	        spi_->SetBufferedByte(pin_, offset + 2, green);
-	        spi_->SetBufferedByte(pin_, offset + 3, red);
-	    }
+            hardwareScale5 = 0;
+            hardwareInverseTable8_[0] = 0;
+            while (++hardwareScale5 < 32u) {
+                hardwareInverseTable8_[hardwareScale5] = (31u << 8) / hardwareScale5;
+            }
+            hardwareInverseTable8Created_ = true;
+        }
     }
 
-    virtual void SetPixel16(uint32_t pixel_index, uint16_t red, uint16_t green, uint16_t blue)
-    {
-    	if (pixel_index < (uint32_t)pixelCount_)
-    	{
-			red = (uint16_t)std::min((uint32_t)((uint64_t)red * redScale16_ / 0x10000), (uint32_t)0xFFFFu);
-			green = (uint16_t)std::min((uint32_t)((uint64_t)green * greenScale16_ / 0x10000), (uint32_t)0xFFFFu);
-			blue = (uint16_t)std::min((uint32_t)((uint64_t)blue * blueScale16_ / 0x10000), (uint32_t)0xFFFFu);
+    virtual void SetBrightnessScale(float redScale, float greenScale, float blueScale) {
+        LEDStrip::SetBrightnessScale(redScale, greenScale, blueScale);
 
-			uint32_t		const maxComponent = std::max(std::max(red, green), blue);
-			uint32_t		const high5Bits = (maxComponent + 1 + 0x03FF) >> 11;
-			uint32_t		const hardwareScale5 = std::max(std::min(high5Bits, 31u), 1u);
-			uint32_t		const hardwareInverse8 = hardwareInverseTable8_[hardwareScale5];
-			
-			red = (uint16_t)std::min(red * hardwareInverse8 / 0x10000, 0xFFu);
-			green = (uint16_t)std::min(green * hardwareInverse8 / 0x10000, 0xFFu);
-			blue = (uint16_t)std::min(blue * hardwareInverse8 / 0x10000, 0xFFu);
-			
-			int				const offset = APA_start_frame_bytes + APA_pixel_bytes * pixel_index;
+        uint32_t        const maxScale = std::max(std::max(redScale16_, greenScale16_), blueScale16_);
 
-			spi_->SetBufferedByte(pin_, offset + 0, (uint8_t)(0xE0 | hardwareScale5));
-			spi_->SetBufferedByte(pin_, offset + 1, (uint8_t)blue);
-			spi_->SetBufferedByte(pin_, offset + 2, (uint8_t)green);
-			spi_->SetBufferedByte(pin_, offset + 3, (uint8_t)red);
-		}
+        if (maxScale < 0x10000) {
+            uint32_t        hardwareScale5;
+
+            // maxScale is 0x10000 for no scaling.
+            // For APA102, we squeeze this range down to 0...31
+            // We disallow 0 since that would just result in blackness.
+            hardwareScale5 = (maxScale + 0x03FFu) >> 11;
+            hardwareScale5 = std::min(hardwareScale5, 31u);
+            hardwareScale5 = std::max(hardwareScale5, 1u);
+            hardwareBrightnessByte_ = (uint8_t)hardwareScale5 | 0xE0;
+
+            // componentsScale16_ scales down the compoent values directly.
+            // It provides more precision, in addition to the crude, 5-bit hardware brightness.
+            componentsRedScale16_ = redScale16_ * 31u / hardwareScale5;
+            componentsGreenScale16_ = greenScale16_ * 31u / hardwareScale5;
+            componentsBlueScale16_ = blueScale16_ * 31u / hardwareScale5;
+        } else {
+            // If scaling up or not scaling, don't use any hardware scaling.
+            // Just let componentsScale16_ do it.
+            hardwareBrightnessByte_ = 0xFF;
+            componentsRedScale16_ = redScale16_;
+            componentsGreenScale16_ = greenScale16_;
+            componentsBlueScale16_ = blueScale16_;
+        }
+
+//      fprintf(stderr, "APA102LedStrip::SetBrightnessScale() - input=0x%04X, hardware=0x%02X, red=0x%04X, green=0x%04X, blue=0x%04X\n",
+//              maxScale, hardwareBrightnessByte_,
+//              componentsRedScale16_, componentsGreenScale16_, componentsBlueScale16_);
+    }
+
+    virtual void SetPixel8(uint32_t pixel_index, uint8_t red, uint8_t green, uint8_t blue) {
+        if (pixel_index < (uint32_t)pixelCount_) {
+            red = (uint8_t)std::min(red * componentsRedScale16_ / 0x10000u, 0xFFu);
+            green = (uint8_t)std::min(green * componentsGreenScale16_ / 0x10000u, 0xFFu);
+            blue = (uint8_t)std::min(blue * componentsBlueScale16_ / 0x10000u, 0xFFu);
+
+            int             const offset = APA_start_frame_bytes + APA_pixel_bytes * pixel_index;
+
+            spi_->SetBufferedByte(pin_, offset + 0, hardwareBrightnessByte_);
+            spi_->SetBufferedByte(pin_, offset + 1, blue);
+            spi_->SetBufferedByte(pin_, offset + 2, green);
+            spi_->SetBufferedByte(pin_, offset + 3, red);
+        }
+    }
+
+    virtual void SetPixel16(uint32_t pixel_index, uint16_t red, uint16_t green, uint16_t blue) {
+        if (pixel_index < (uint32_t)pixelCount_) {
+            red = (uint16_t)std::min((uint32_t)((uint64_t)red * redScale16_ / 0x10000), (uint32_t)0xFFFFu);
+            green = (uint16_t)std::min((uint32_t)((uint64_t)green * greenScale16_ / 0x10000), (uint32_t)0xFFFFu);
+            blue = (uint16_t)std::min((uint32_t)((uint64_t)blue * blueScale16_ / 0x10000), (uint32_t)0xFFFFu);
+
+            uint32_t        const maxComponent = std::max(std::max(red, green), blue);
+            uint32_t        const high5Bits = (maxComponent + 1 + 0x03FF) >> 11;
+            uint32_t        const hardwareScale5 = std::max(std::min(high5Bits, 31u), 1u);
+            uint32_t        const hardwareInverse8 = hardwareInverseTable8_[hardwareScale5];
+
+            red = (uint16_t)std::min(red * hardwareInverse8 / 0x10000, 0xFFu);
+            green = (uint16_t)std::min(green * hardwareInverse8 / 0x10000, 0xFFu);
+            blue = (uint16_t)std::min(blue * hardwareInverse8 / 0x10000, 0xFFu);
+
+            int             const offset = APA_start_frame_bytes + APA_pixel_bytes * pixel_index;
+
+            spi_->SetBufferedByte(pin_, offset + 0, (uint8_t)(0xE0 | hardwareScale5));
+            spi_->SetBufferedByte(pin_, offset + 1, (uint8_t)blue);
+            spi_->SetBufferedByte(pin_, offset + 2, (uint8_t)green);
+            spi_->SetBufferedByte(pin_, offset + 3, (uint8_t)red);
+        }
     }
 
 private:
-    MultiSPI*		const spi_;
-    MultiSPI::Pin	const pin_;
-    uint32_t		componentsRedScale16_;				// scales component values before sending to spi_
-    uint32_t		componentsGreenScale16_;			// scales component values before sending to spi_
-    uint32_t		componentsBlueScale16_;				// scales component values before sending to spi_
-    uint8_t			hardwareBrightnessByte_;			// byte sent to APA102 when SetPixel8() used
+    MultiSPI*       const spi_;
+    MultiSPI::Pin   const pin_;
+    uint32_t        componentsRedScale16_;              // scales component values before sending to spi_
+    uint32_t        componentsGreenScale16_;            // scales component values before sending to spi_
+    uint32_t        componentsBlueScale16_;             // scales component values before sending to spi_
+    uint8_t         hardwareBrightnessByte_;            // byte sent to APA102 when SetPixel8() used
 
-static bool			hardwareInverseTable8Created_;
-static uint32_t		hardwareInverseTable8_[32];	// used by SetPixel16() to quickly divide
+static bool         hardwareInverseTable8Created_;
+static uint32_t     hardwareInverseTable8_[32];         // used by SetPixel16() to quickly divide
 };
 
-bool			APA102LedStrip::hardwareInverseTable8Created_ = false;
-uint32_t		APA102LedStrip::hardwareInverseTable8_[32];
+bool            APA102LedStrip::hardwareInverseTable8Created_ = false;
+uint32_t        APA102LedStrip::hardwareInverseTable8_[32];
 
 
 /////////////////////////////////////////////////
@@ -411,146 +323,130 @@ uint32_t		APA102LedStrip::hardwareInverseTable8_[32];
 // They are created slightly differently, to adjust color as lower and lower global brightness
 // values are used.  When no hardware dimmings is used, they don't scale components at all.
 
-class SK9822LedStrip : public LEDStrip
-{
+class SK9822LedStrip : public LEDStrip {
 public:
     SK9822LedStrip(MultiSPI *spi, MultiSPI::Pin pin, int pixelCount)
-	: LEDStrip(pixelCount)
-	, spi_(spi)
-	, pin_(pin)
-	{
+    : LEDStrip(pixelCount), spi_(spi), pin_(pin) {
         const size_t pixels_bytes = APA_pixel_bytes * pixelCount;
         const size_t end_frame_bytes = APA_latch_frame_bytes + (pixelCount + 15) / 16;
         const size_t frame_bytes = APA_start_frame_bytes + pixels_bytes + end_frame_bytes;
 
         spi_->RegisterDataGPIO(pin, frame_bytes);
 
-		componentsRedScale16_ = 0x10000;
-		componentsGreenScale16_ = 0x10000;
-		componentsBlueScale16_ = 0x10000;
-		hardwareBrightnessByte_ = 0x1F;
+        componentsRedScale16_ = 0x10000;
+        componentsGreenScale16_ = 0x10000;
+        componentsBlueScale16_ = 0x10000;
+        hardwareBrightnessByte_ = 0x1F;
 
-		if (!hardwareInverseTablesCreated_)
-		{
-			uint32_t		hardwareScale5;
-			
-			hardwareScale5 = 0;
-			hardwareRedInverseTable8_[0] = 0;
-			hardwareGreenInverseTable8_[0] = 0;
-			hardwareBlueInverseTable8_[0] = 0;
-			while (++hardwareScale5 < 32u)
-			{
-				hardwareRedInverseTable8_[hardwareScale5] = (31u * 0xF0) / hardwareScale5 + (0x100 - 0xF0);
-				hardwareGreenInverseTable8_[hardwareScale5] = (31u * 0x80) / hardwareScale5 + (0x100 - 0x80);
-				hardwareBlueInverseTable8_[hardwareScale5] = (31u * 0x80) / hardwareScale5 + (0x100 - 0x80);
-			}
-			hardwareInverseTablesCreated_ = true;
-		}
+        if (!hardwareInverseTablesCreated_) {
+            uint32_t        hardwareScale5;
+
+            hardwareScale5 = 0;
+            hardwareRedInverseTable8_[0] = 0;
+            hardwareGreenInverseTable8_[0] = 0;
+            hardwareBlueInverseTable8_[0] = 0;
+            while (++hardwareScale5 < 32u) {
+                hardwareRedInverseTable8_[hardwareScale5] = (31u * 0xF0) / hardwareScale5 + (0x100 - 0xF0);
+                hardwareGreenInverseTable8_[hardwareScale5] = (31u * 0x80) / hardwareScale5 + (0x100 - 0x80);
+                hardwareBlueInverseTable8_[hardwareScale5] = (31u * 0x80) / hardwareScale5 + (0x100 - 0x80);
+            }
+            hardwareInverseTablesCreated_ = true;
+        }
     }
 
-	virtual void SetBrightnessScale16(uint32_t redScale16, uint32_t greenScale16, uint32_t blueScale16)
-	{
-		redScale16_ = redScale16;
-		greenScale16_ = greenScale16;
-		blueScale16_ = blueScale16;
+    virtual void SetBrightnessScale(float redScale, float greenScale, float blueScale) {
+        LEDStrip::SetBrightnessScale(redScale, greenScale, blueScale);
 
-		uint32_t		const maxScale = std::max(std::max(redScale16, greenScale16), blueScale16);
-				
-    	if (maxScale < 0x10000)
-    	{
-    		uint32_t		hardwareScale5;
-    		
-    		// brightnessScale16 is 0x10000 for no scaling.
-    		// For APA102, we squeeze this range down to 0...31
-    		// We disallow 0 since that would just result in blackness.
-    		hardwareScale5 = (maxScale + 0x03FFu) >> 11;
-    		hardwareScale5 = std::min(hardwareScale5, 31u);
-    		hardwareScale5 = std::max(hardwareScale5, 1u);
-    		hardwareBrightnessByte_ = (uint8_t)hardwareScale5 | 0xE0;
-    		
-    		// componentsScale16_ scales down the compoent values directly.
-    		// It provides more precision, in addition to the crude, 5-bit hardware brightness.
-    		componentsRedScale16_ = redScale16 * hardwareRedInverseTable8_[hardwareScale5] / 0x100;
-    		componentsGreenScale16_ = greenScale16 * hardwareGreenInverseTable8_[hardwareScale5] / 0x100;
-    		componentsBlueScale16_ = blueScale16 * hardwareBlueInverseTable8_[hardwareScale5] / 0x100;
-    	}
-    	else
-    	{
-    		// If scaling up or not scaling, don't use any hardware scaling.
-    		// Just let componentsScale16_ do it.
-    		hardwareBrightnessByte_ = 0xFF;
-    		componentsRedScale16_ = redScale16;
-    		componentsGreenScale16_ = greenScale16;
-    		componentsBlueScale16_ = blueScale16;
-    	}
+        uint32_t        const maxScale = std::max(std::max(redScale16_, greenScale16_), blueScale16_);
 
-//		fprintf(stderr, "SK9822LedStrip::SetBrightnessScale16() - input=0x%04X, hardware=0x%02X, red=0x%04X, green=0x%04X, blue=0x%04X\n",
-//				maxScale, hardwareBrightnessByte_ & 0x1F,
-//				componentsRedScale16_, componentsGreenScale16_, componentsBlueScale16_);
-	}
-	
-    virtual void SetPixel8(uint32_t pixel_index, uint8_t red, uint8_t green, uint8_t blue)
-    {
-    	if (pixel_index < (uint32_t)pixelCount_)
-    	{
-    		red = (uint8_t)std::min(red * componentsRedScale16_ / 0x10000u, 0xFFu);
-    		green = (uint8_t)std::min(green * componentsGreenScale16_ / 0x10000u, 0xFFu);
-    		blue = (uint8_t)std::min(blue * componentsBlueScale16_ / 0x10000u, 0xFFu);
+        if (maxScale < 0x10000) {
+            uint32_t        hardwareScale5;
 
-	        int				const offset = APA_start_frame_bytes + APA_pixel_bytes * pixel_index;
+            // maxScale is 0x10000 for no scaling.
+            // For SK9822, we squeeze this range down to 0...31
+            // We disallow 0 since that would just result in blackness.
+            hardwareScale5 = (maxScale + 0x03FFu) >> 11;
+            hardwareScale5 = std::min(hardwareScale5, 31u);
+            hardwareScale5 = std::max(hardwareScale5, 1u);
+            hardwareBrightnessByte_ = (uint8_t)hardwareScale5 | 0xE0;
 
-			spi_->SetBufferedByte(pin_, offset + 0, hardwareBrightnessByte_);
-	        spi_->SetBufferedByte(pin_, offset + 1, blue);
-	        spi_->SetBufferedByte(pin_, offset + 2, green);
-	        spi_->SetBufferedByte(pin_, offset + 3, red);
-	    }
+            // componentsScale16_ scales down the compoent values directly.
+            // It provides more precision, in addition to the crude, 5-bit hardware brightness.
+            componentsRedScale16_ = redScale16_ * hardwareRedInverseTable8_[hardwareScale5] / 0x100;
+            componentsGreenScale16_ = greenScale16_ * hardwareGreenInverseTable8_[hardwareScale5] / 0x100;
+            componentsBlueScale16_ = blueScale16_ * hardwareBlueInverseTable8_[hardwareScale5] / 0x100;
+        } else {
+            // If scaling up or not scaling, don't use any hardware scaling.
+            // Just let componentsScale16_ do it.
+            hardwareBrightnessByte_ = 0xFF;
+            componentsRedScale16_ = redScale16_;
+            componentsGreenScale16_ = greenScale16_;
+            componentsBlueScale16_ = blueScale16_;
+        }
+
+//      fprintf(stderr, "SK9822LedStrip::SetBrightnessScale() - input=0x%04X, hardware=0x%02X, red=0x%04X, green=0x%04X, blue=0x%04X\n",
+//              maxScale, hardwareBrightnessByte_ & 0x1F,
+//              componentsRedScale16_, componentsGreenScale16_, componentsBlueScale16_);
     }
-    
-    virtual void SetPixel16(uint32_t pixel_index, uint16_t red, uint16_t green, uint16_t blue)
-    {
-    	if (pixel_index < (uint32_t)pixelCount_)
-    	{
-			red = (uint16_t)std::min((uint32_t)((uint64_t)red * redScale16_ / 0x10000), (uint32_t)0xFFFFu);
-			green = (uint16_t)std::min((uint32_t)((uint64_t)green * greenScale16_ / 0x10000), (uint32_t)0xFFFFu);
-			blue = (uint16_t)std::min((uint32_t)((uint64_t)blue * blueScale16_ / 0x10000), (uint32_t)0xFFFFu);
 
-			uint32_t		const maxComponent = std::max(std::max(red, green), blue);
-			uint32_t		const high5Bits = (maxComponent + 1 + 0x03FF) >> 11;
-			uint32_t		const hardwareScale5 = std::max(std::min(high5Bits, 31u), 1u);
-			
-			red = (uint16_t)std::min(red * hardwareRedInverseTable8_[hardwareScale5] / 0x10000, 0xFFu);
-			green = (uint16_t)std::min(green * hardwareGreenInverseTable8_[hardwareScale5] / 0x10000, 0xFFu);
-			blue = (uint16_t)std::min(blue * hardwareBlueInverseTable8_[hardwareScale5] / 0x10000, 0xFFu);
-			
-			int				const offset = APA_start_frame_bytes + APA_pixel_bytes * pixel_index;
+    virtual void SetPixel8(uint32_t pixel_index, uint8_t red, uint8_t green, uint8_t blue) {
+        if (pixel_index < (uint32_t)pixelCount_) {
+            red = (uint8_t)std::min(red * componentsRedScale16_ / 0x10000u, 0xFFu);
+            green = (uint8_t)std::min(green * componentsGreenScale16_ / 0x10000u, 0xFFu);
+            blue = (uint8_t)std::min(blue * componentsBlueScale16_ / 0x10000u, 0xFFu);
 
-			spi_->SetBufferedByte(pin_, offset + 0, (uint8_t)(0xE0 | hardwareScale5));
-			spi_->SetBufferedByte(pin_, offset + 1, (uint8_t)blue);
-			spi_->SetBufferedByte(pin_, offset + 2, (uint8_t)green);
-			spi_->SetBufferedByte(pin_, offset + 3, (uint8_t)red);
-		}
+            int             const offset = APA_start_frame_bytes + APA_pixel_bytes * pixel_index;
+
+            spi_->SetBufferedByte(pin_, offset + 0, hardwareBrightnessByte_);
+            spi_->SetBufferedByte(pin_, offset + 1, blue);
+            spi_->SetBufferedByte(pin_, offset + 2, green);
+            spi_->SetBufferedByte(pin_, offset + 3, red);
+        }
+    }
+
+    virtual void SetPixel16(uint32_t pixel_index, uint16_t red, uint16_t green, uint16_t blue) {
+        if (pixel_index < (uint32_t)pixelCount_) {
+            red = (uint16_t)std::min((uint32_t)((uint64_t)red * redScale16_ / 0x10000), (uint32_t)0xFFFFu);
+            green = (uint16_t)std::min((uint32_t)((uint64_t)green * greenScale16_ / 0x10000), (uint32_t)0xFFFFu);
+            blue = (uint16_t)std::min((uint32_t)((uint64_t)blue * blueScale16_ / 0x10000), (uint32_t)0xFFFFu);
+
+            uint32_t        const maxComponent = std::max(std::max(red, green), blue);
+            uint32_t        const high5Bits = (maxComponent + 1 + 0x03FF) >> 11;
+            uint32_t        const hardwareScale5 = std::max(std::min(high5Bits, 31u), 1u);
+
+            red = (uint16_t)std::min(red * hardwareRedInverseTable8_[hardwareScale5] / 0x10000, 0xFFu);
+            green = (uint16_t)std::min(green * hardwareGreenInverseTable8_[hardwareScale5] / 0x10000, 0xFFu);
+            blue = (uint16_t)std::min(blue * hardwareBlueInverseTable8_[hardwareScale5] / 0x10000, 0xFFu);
+
+            int             const offset = APA_start_frame_bytes + APA_pixel_bytes * pixel_index;
+
+            spi_->SetBufferedByte(pin_, offset + 0, (uint8_t)(0xE0 | hardwareScale5));
+            spi_->SetBufferedByte(pin_, offset + 1, (uint8_t)blue);
+            spi_->SetBufferedByte(pin_, offset + 2, (uint8_t)green);
+            spi_->SetBufferedByte(pin_, offset + 3, (uint8_t)red);
+        }
     }
 
 protected:
-    MultiSPI*		const spi_;
-    MultiSPI::Pin	const pin_;
-    
-private:
-    uint32_t		componentsRedScale16_;				// scales component values before sending to spi_
-    uint32_t		componentsGreenScale16_;			// scales component values before sending to spi_
-    uint32_t		componentsBlueScale16_;				// scales component values before sending to spi_
-    uint8_t			hardwareBrightnessByte_;			// byte sent to APA102 when SetPixel8() used
+    MultiSPI*       const spi_;
+    MultiSPI::Pin   const pin_;
 
-static bool			hardwareInverseTablesCreated_;
-static uint32_t		hardwareRedInverseTable8_[32];		// used by SetPixel16() to quickly divide
-static uint32_t		hardwareGreenInverseTable8_[32];	// used by SetPixel16() to quickly divide
-static uint32_t		hardwareBlueInverseTable8_[32];		// used by SetPixel16() to quickly divide
+private:
+    uint32_t        componentsRedScale16_;              // scales component values before sending to spi_
+    uint32_t        componentsGreenScale16_;            // scales component values before sending to spi_
+    uint32_t        componentsBlueScale16_;             // scales component values before sending to spi_
+    uint8_t         hardwareBrightnessByte_;            // byte sent to APA102 when SetPixel8() used
+
+static bool         hardwareInverseTablesCreated_;
+static uint32_t     hardwareRedInverseTable8_[32];      // used by SetPixel16() to quickly divide
+static uint32_t     hardwareGreenInverseTable8_[32];    // used by SetPixel16() to quickly divide
+static uint32_t     hardwareBlueInverseTable8_[32];     // used by SetPixel16() to quickly divide
 };
 
-bool			SK9822LedStrip::hardwareInverseTablesCreated_ = false;
-uint32_t		SK9822LedStrip::hardwareRedInverseTable8_[32];
-uint32_t		SK9822LedStrip::hardwareGreenInverseTable8_[32];
-uint32_t		SK9822LedStrip::hardwareBlueInverseTable8_[32];
+bool            SK9822LedStrip::hardwareInverseTablesCreated_ = false;
+uint32_t        SK9822LedStrip::hardwareRedInverseTable8_[32];
+uint32_t        SK9822LedStrip::hardwareGreenInverseTable8_[32];
+uint32_t        SK9822LedStrip::hardwareBlueInverseTable8_[32];
 
 
 }  // anonymous namespace

--- a/lib/led-strip.cc
+++ b/lib/led-strip.cc
@@ -22,6 +22,10 @@
 #include "multi-spi.h"
 #include "led-strip.h"
 
+#define DO_CIE1931		FALSE
+
+
+/*
 typedef uint16_t CIEValue;
 
 // Do CIE1931 luminance correction and scale to maximum expected output bits.
@@ -47,16 +51,26 @@ static CIEValue luminance_cie1931(uint8_t value, uint8_t bright) {
     static const CIEValue *const luminance_lookup = CreateCIE1931LookupTable();
     return luminance_lookup[bright * 256 + value];
 }
+*/
 
 namespace spixels {
-LEDStrip::LEDStrip(int count)
-    : count_(count), values_(new RGBc[count]), brightness_(255) {
+LEDStrip::LEDStrip(int pixelCount)
+    : pixelCount_(pixelCount)
+/*
+    , values_(new RGBc[pixelCount])
+    , brightness_(255)
+*/
+{
 }
 
-LEDStrip::~LEDStrip() { delete values_; }
+LEDStrip::~LEDStrip()
+{
+//	delete values_;
+}
 
+/*
 void LEDStrip::SetPixel(int pos, const RGBc& c) {
-    if (pos < 0 || pos >= count()) return;
+    if (pos < 0 || pos >= pixelCount()) return;
     values_[pos] = c;
     SetLinearValues(pos,
                     luminance_cie1931(c.r, brightness_),
@@ -67,132 +81,224 @@ void LEDStrip::SetPixel(int pos, const RGBc& c) {
 void LEDStrip::SetBrightness(uint8_t new_brightness) {
     if (new_brightness == brightness_) return;
     brightness_ = new_brightness;
-    for (int i = 0; i < count_; ++i) {
+    for (int i = 0; i < pixelCount_; ++i) {
         SetPixel(i, values_[i]);  // Force recalculation.
     }
 }
+*/
 
 namespace {
+
+
+/////////////////////////////////////////////////
+//#pragma mark - WS2801LedStrip:
+
 class WS2801LedStrip : public LEDStrip {
 public:
-    WS2801LedStrip(MultiSPI *spi, int gpio, int count)
-        : LEDStrip(count), spi_(spi), gpio_(gpio) {
-        spi_->RegisterDataGPIO(gpio, count * 3);
+    WS2801LedStrip(MultiSPI *spi, MultiSPI::Pin pin, int pixelCount)
+        : LEDStrip(pixelCount), spi_(spi), pin_(pin) {
+        spi_->RegisterDataGPIO(pin, pixelCount * 3);
     }
 
-    virtual void SetLinearValues(int pos, uint16_t r, uint16_t g, uint16_t b) {
-        spi_->SetBufferedByte(gpio_, 3 * pos + 0, r >> 8);
-        spi_->SetBufferedByte(gpio_, 3 * pos + 1, g >> 8);
-        spi_->SetBufferedByte(gpio_, 3 * pos + 2, b >> 8);
+    virtual void SetPixel8(int pixelIndex, uint8_t red, uint8_t green, uint8_t blue)
+    {
+        spi_->SetBufferedByte(pin_, pixelIndex + 0, red);
+        spi_->SetBufferedByte(pin_, pixelIndex + 1, green);
+        spi_->SetBufferedByte(pin_, pixelIndex + 2, blue);
+    }
+    virtual void SetPixel16(int pixelIndex, uint16_t red, uint16_t green, uint16_t blue)
+    {
+        spi_->SetBufferedByte(pin_, pixelIndex + 0, (uint8_t)(red >> 8));
+        spi_->SetBufferedByte(pin_, pixelIndex + 1, (uint8_t)(green >> 8));
+        spi_->SetBufferedByte(pin_, pixelIndex + 2, (uint8_t)(blue >> 8));
     }
 
 private:
     MultiSPI *const spi_;
-    const int gpio_;
+    const MultiSPI::Pin pin_;
 };
+
+
+/////////////////////////////////////////////////
+//#pragma mark - LPD6803LedStrip:
 
 class LPD6803LedStrip : public LEDStrip {
 public:
-    LPD6803LedStrip(MultiSPI *spi, int gpio, int count)
-        : LEDStrip(count), spi_(spi), gpio_(gpio) {
-        const size_t bytes_needed = 4 + 2 * count + 4;
-        spi_->RegisterDataGPIO(gpio, bytes_needed);
+    LPD6803LedStrip(MultiSPI *spi, MultiSPI::Pin pin, int pixelCount)
+        : LEDStrip(pixelCount), spi_(spi), pin_(pin) {
+        const size_t bytes_needed = 4 + 2 * pixelCount + 4;
+        spi_->RegisterDataGPIO(pin, bytes_needed);
 
         // Four zero bytes as start-bytes for lpd6803
-        spi_->SetBufferedByte(gpio_, 0, 0x00);
-        spi_->SetBufferedByte(gpio_, 1, 0x00);
-        spi_->SetBufferedByte(gpio_, 2, 0x00);
-        spi_->SetBufferedByte(gpio_, 3, 0x00);
-        for (int pos = 0; pos < count; ++pos) {
-            SetPixel(pos, 0x000000);     // Initialize all top-bits.
+        spi_->SetBufferedByte(pin_, 0, 0x00);
+        spi_->SetBufferedByte(pin_, 1, 0x00);
+        spi_->SetBufferedByte(pin_, 2, 0x00);
+        spi_->SetBufferedByte(pin_, 3, 0x00);
+        for (int pos = 0; pos < pixelCount; ++pos)
+        {
+            SetPixel8(pos, 0, 0, 0);     // Initialize all top-bits.
         }
     }
 
-    virtual void SetLinearValues(int pos, uint16_t r, uint16_t g, uint16_t b) {
-        uint16_t data = 0;
-        data |= (1<<15);  // start bit
-        data |= (r >> 11) << 10;
-        data |= (g >> 11) <<  5;
-        data |= (b >> 11) <<  0;
+    virtual void SetPixel8(int pixelIndex, uint8_t red, uint8_t green, uint8_t blue)
+    {
+        uint16_t		data;
+        
+        data = (1<<15);  // start bit
+        data |= (red >> 3) << 10;
+        data |= (green >> 3) <<  5;
+        data |= (blue >> 3) <<  0;
 
-        spi_->SetBufferedByte(gpio_, 2 * pos + 4 + 0, data >> 8);
-        spi_->SetBufferedByte(gpio_, 2 * pos + 4 + 1, data & 0xFF);
+		int				const offset = 4 + 2 * pixelIndex;
+		
+        spi_->SetBufferedByte(pin_, offset + 0, data >> 8);
+        spi_->SetBufferedByte(pin_, offset + 1, data & 0xFF);
+    }
+    virtual void SetPixel16(int pixelIndex, uint16_t red, uint16_t green, uint16_t blue)
+    {
+        uint16_t		data;
+        
+        data = (1<<15);  // start bit
+        data |= (red >> 11) << 10;
+        data |= (green >> 11) <<  5;
+        data |= (blue >> 11) <<  0;
+
+		int				const offset = 4 + 2 * pixelIndex;
+		
+        spi_->SetBufferedByte(pin_, offset + 0, data >> 8);
+        spi_->SetBufferedByte(pin_, offset + 1, data & 0xFF);
     }
 
 private:
     MultiSPI *const spi_;
-    const int gpio_;
+    const MultiSPI::Pin pin_;
 };
 
-class APA102LedStrip : public LEDStrip {
-public:
-    APA102LedStrip(MultiSPI *spi, int gpio, int count)
-        : LEDStrip(count), spi_(spi), gpio_(gpio) {
-        const size_t startframe_size = 4;
-        const size_t endframe_size = (count+15) / 16;
-        const size_t bytes_needed = startframe_size + 4*count + endframe_size;
 
-        spi_->RegisterDataGPIO(gpio, bytes_needed);
+/////////////////////////////////////////////////
+//#pragma mark - APA102LedStrip:
+
+class APA102LedStrip : public LEDStrip
+{
+public:
+    APA102LedStrip(MultiSPI *spi, MultiSPI::Pin pin, int pixelCount)
+	: LEDStrip(pixelCount)
+	, spi_(spi)
+	, pin_(pin)
+	{
+        const size_t startframe_size = 4;
+        const size_t data_size = 4*pixelCount;
+        const size_t endframe_size = (pixelCount+15) / 16;
+        const size_t bytes_needed = startframe_size + data_size + endframe_size;
+
+        spi_->RegisterDataGPIO(pin, bytes_needed);
 
         // Four zero bytes as start-bytes
-        spi_->SetBufferedByte(gpio_, 0, 0x00);
-        spi_->SetBufferedByte(gpio_, 1, 0x00);
-        spi_->SetBufferedByte(gpio_, 2, 0x00);
-        spi_->SetBufferedByte(gpio_, 3, 0x00);
+        spi_->SetBufferedByte(pin_, 0, 0x00);
+        spi_->SetBufferedByte(pin_, 1, 0x00);
+        spi_->SetBufferedByte(pin_, 2, 0x00);
+        spi_->SetBufferedByte(pin_, 3, 0x00);
 
         // Make sure the start bits are properly set.
-        for (int i = 0; i < count; ++i) {
-            SetPixel(i, 0x000000);
+        for (int i = 0; i < pixelCount; ++i)
+        {
+            SetPixel8(i, 0, 0, 0);
         }
 
+		// TODO:  Add "reset frame" to support APA102 clone chip
+		
         // We need a couple of more bits clocked at the end.
-        for (size_t tail = 4 + 4*count; tail < bytes_needed; ++tail) {
-            spi_->SetBufferedByte(gpio_, tail, 0xff);
+        for (size_t tail = startframe_size + data_size; tail < bytes_needed; ++tail)
+        {
+            spi_->SetBufferedByte(pin_, tail, 0xff);
         }
+
+		uint32_t		index;
+		
+		index = 0;
+		reciprocalTable8_[0] = 0;
+		while (++index < 32)
+		{
+			reciprocalTable8_[index] = (0x1F << 8) / index;
+		}
     }
 
-    virtual void SetLinearValues(int pos, uint16_t r, uint16_t g, uint16_t b) {
-        const int base = 4 + 4 * pos;
-        r >>= 4; g >>= 4; b >>= 4;
+    virtual void SetPixel8(int pixelIndex, uint8_t red, uint8_t green, uint8_t blue)
+    {
+        int				const offset = 4 + 4 * pixelIndex;
 
-        // If value is dim, use the APA global brightness adjustment for
-        // more resolution. We essentially get 4 bits at the bottom end.
-        const uint16_t bit_use = r | g | b;  // find highest bit used.
-        if (bit_use < 16) {
-            spi_->SetBufferedByte(gpio_, base + 0, 0xE0 | 0x01);
-        } else if (bit_use < 32) {
-            spi_->SetBufferedByte(gpio_, base + 0, 0xE0 | 0x03);
-            r >>= 1; g >>= 1; b >>= 1;
-        } else if (bit_use < 64) {
-            spi_->SetBufferedByte(gpio_, base + 0, 0xE0 | 0x07);
-            r >>= 2; g >>= 2; b >>= 2;
-        } else if (bit_use < 128) {
-            spi_->SetBufferedByte(gpio_, base + 0, 0xE0 | 0x0F);
-            r >>= 3; g >>= 3; b >>= 3;
-        } else {
-            spi_->SetBufferedByte(gpio_, base + 0, 0xE0 | 0x1F);
-            r >>= 4; g >>= 4; b >>= 4;
-        }
+		spi_->SetBufferedByte(pin_, offset + 0, 0xFF);
+        spi_->SetBufferedByte(pin_, offset + 1, blue);
+        spi_->SetBufferedByte(pin_, offset + 2, green);
+        spi_->SetBufferedByte(pin_, offset + 3, red);
+    }
+    virtual void SetPixel8(int pixelIndex, uint8_t red, uint8_t green, uint8_t blue, uint32_t brightnessScale)
+    {
+   		uint32_t		multiplier;
 
-        spi_->SetBufferedByte(gpio_, base + 1, b);
-        spi_->SetBufferedByte(gpio_, base + 2, g);
-        spi_->SetBufferedByte(gpio_, base + 3, r);
+    	if (brightnessScale > 0x10000)
+    	{
+    		red = (uint8_t)std::min(red * brightnessScale / 0x10000, (uint32_t)0xFF);
+    		green = (uint8_t)std::min(green * brightnessScale / 0x10000, (uint32_t)0xFF);
+    		blue = (uint8_t)std::min(blue * brightnessScale / 0x10000, (uint32_t)0xFF);
+    		multiplier = 0x1F;
+    	}
+    	else if (brightnessScale < 0x10000)
+    	{
+    		multiplier = (brightnessScale + 0x07FF) >> 11;
+    		if (multiplier < 0x01) multiplier = 0x01;
+    		else if (multiplier > 0x1F) multiplier = 0x1F;
+    		brightnessScale = (brightnessScale * reciprocalTable8_[multiplier]) >> 8;
+    		red = (uint8_t)(red * brightnessScale / 0x10000);
+    		green = (uint8_t)(green * brightnessScale / 0x10000);
+    		blue = (uint8_t)(blue * brightnessScale / 0x10000);
+    	}
+    	else
+    	{
+    		multiplier = 0x1F;
+    	}
+
+        int				const offset = 4 + 4 * pixelIndex;
+
+		spi_->SetBufferedByte(pin_, offset + 0, (uint8_t)(0xE0 | multiplier));
+        spi_->SetBufferedByte(pin_, offset + 1, blue);
+        spi_->SetBufferedByte(pin_, offset + 2, green);
+        spi_->SetBufferedByte(pin_, offset + 3, red);
+    }
+    virtual void SetPixel16(int pixelIndex, uint16_t red, uint16_t green, uint16_t blue)
+    {
+		uint16_t			const maxHigh5Bits = std::max(std::max(red, green), blue) >> 11;
+		uint16_t			const multiplier = std::min(maxHigh5Bits + 1, 31);
+		uint32_t			const reciprocal8 = reciprocalTable8_[multiplier];
+		
+		red = (uint16_t)(red * reciprocal8 / 0x10000);
+		green = (uint16_t)(green * reciprocal8 / 0x10000);
+		blue = (uint16_t)(blue * reciprocal8 / 0x10000);
+		
+        int					const offset = 4 + 4 * pixelIndex;
+
+		spi_->SetBufferedByte(pin_, offset + 0, (uint8_t)(0xE0 | multiplier));
+        spi_->SetBufferedByte(pin_, offset + 1, (uint8_t)blue);
+        spi_->SetBufferedByte(pin_, offset + 2, (uint8_t)green);
+        spi_->SetBufferedByte(pin_, offset + 3, (uint8_t)red);
     }
 
 private:
-    MultiSPI *const spi_;
-    const int gpio_;
+    MultiSPI*		const spi_;
+    MultiSPI::Pin	const pin_;
+   	uint32_t		reciprocalTable8_[32];
 };
+
 }  // anonymous namespace
 
 // Public interface
-LEDStrip *CreateWS2801Strip(MultiSPI *spi, int connector, int count) {
-    return new WS2801LedStrip(spi, connector, count);
+LEDStrip *CreateWS2801Strip(MultiSPI *spi, MultiSPI::Pin pin, int pixelCount) {
+    return new WS2801LedStrip(spi, pin, pixelCount);
 }
-LEDStrip *CreateLPD6803Strip(MultiSPI *spi, int connector, int count) {
-    return new LPD6803LedStrip(spi, connector, count);
+LEDStrip *CreateLPD6803Strip(MultiSPI *spi, MultiSPI::Pin pin, int pixelCount) {
+    return new LPD6803LedStrip(spi, pin, pixelCount);
 }
-LEDStrip *CreateAPA102Strip(MultiSPI *spi, int connector, int count) {
-    return new APA102LedStrip(spi, connector, count);
+LEDStrip *CreateAPA102Strip(MultiSPI *spi, MultiSPI::Pin pin, int pixelCount) {
+    return new APA102LedStrip(spi, pin, pixelCount);
 }
 }  // spixels namespace

--- a/lib/mailbox.c
+++ b/lib/mailbox.c
@@ -93,7 +93,7 @@ static int mbox_property(int file_desc, void *buf)
 
 #ifdef DEBUG
    unsigned *p = buf; int i; unsigned size = *(unsigned *)buf;
-   for (i=0; (unsigned)i<size/4; i++)
+   for (i=0; i<size/4; i++)
       printf("%04lx: 0x%08x\n", i*sizeof *p, p[i]);
 #endif
    return ret_val;

--- a/lib/mailbox.c
+++ b/lib/mailbox.c
@@ -93,8 +93,8 @@ static int mbox_property(int file_desc, void *buf)
 
 #ifdef DEBUG
    unsigned *p = buf; int i; unsigned size = *(unsigned *)buf;
-   for (i=0; i<size/4; i++)
-      printf("%04x: 0x%08x\n", i*sizeof *p, p[i]);
+   for (i=0; (unsigned)i<size/4; i++)
+      printf("%04lx: 0x%08x\n", i*sizeof *p, p[i]);
 #endif
    return ret_val;
 }

--- a/lib/mailbox.c
+++ b/lib/mailbox.c
@@ -92,7 +92,7 @@ static int mbox_property(int file_desc, void *buf)
    }
 
 #ifdef DEBUG
-   unsigned *p = buf; int i; unsigned size = *(unsigned *)buf;
+   unsigned *p = buf; unsigned i; unsigned size = *(unsigned *)buf;
    for (i=0; i<size/4; i++)
       printf("%04lx: 0x%08x\n", i*sizeof *p, p[i]);
 #endif

--- a/lib/mailbox.h
+++ b/lib/mailbox.h
@@ -28,7 +28,9 @@ Original:
 https://github.com/raspberrypi/userland/blob/master/host_applications/linux/apps/hello_pi/hello_fft/mailbox.h
 */
 
+#if !__APPLE__
 #include <linux/ioctl.h>
+#endif
 
 #define MAJOR_NUM 100
 #define IOCTL_MBOX_PROPERTY _IOWR(MAJOR_NUM, 0, char *)

--- a/lib/mailbox.h
+++ b/lib/mailbox.h
@@ -28,8 +28,8 @@ Original:
 https://github.com/raspberrypi/userland/blob/master/host_applications/linux/apps/hello_pi/hello_fft/mailbox.h
 */
 
-#if !__APPLE__
-#include <linux/ioctl.h>
+#ifndef __APPLE__
+    #include <linux/ioctl.h>
 #endif
 
 #define MAJOR_NUM 100

--- a/lib/rpi-dma.c
+++ b/lib/rpi-dma.c
@@ -47,10 +47,10 @@ struct UncachedMemBlock UncachedMemBlock_alloc(size_t size) {
 
     struct UncachedMemBlock result;
     result.size = size;
-    result.mem_handle = mem_alloc(mbox_fd, size, PAGE_SIZE,
+    result.mem_handle = mem_alloc(mbox_fd, (unsigned int)size, PAGE_SIZE,
                                   MEM_FLAG_L1_NONALLOCATING);
     result.bus_addr = mem_lock(mbox_fd, result.mem_handle);
-    result.mem = mapmem(BUS_TO_PHYS(result.bus_addr), size);
+    result.mem = mapmem(BUS_TO_PHYS(result.bus_addr), (unsigned int)size);
     assert(result.bus_addr);  // otherwise: couldn't allocate contiguous block.
     memset(result.mem, 0x00, size);
 
@@ -61,7 +61,7 @@ struct UncachedMemBlock UncachedMemBlock_alloc(size_t size) {
 void UncachedMemBlock_free(struct UncachedMemBlock *block) {
     if (block->mem == NULL) return;
     assert(mbox_fd >= 0);  // someone should've initialized that on allocate.
-    unmapmem(block->mem, block->size);
+    unmapmem(block->mem, (unsigned int)block->size);
     mem_unlock(mbox_fd, block->mem_handle);
     mem_free(mbox_fd, block->mem_handle);
     block->mem = NULL;
@@ -72,7 +72,7 @@ void UncachedMemBlock_free(struct UncachedMemBlock *block) {
 // physical bus addresse needed by DMA operations.
 uintptr_t UncachedMemBlock_to_physical(const struct UncachedMemBlock *blk,
 				       void *p) {
-    uint32_t offset = (uint8_t*)p - (uint8_t*)blk->mem;
+    uint32_t offset = (uint32_t)((uint8_t*)p - (uint8_t*)blk->mem);
     assert(offset < blk->size);   // pointer not within our block.
     return blk->bus_addr + offset;
 }


### PR DESCRIPTION
• Created LPD8806 led-strip
• Developed APA102 led-strip to make use of 5-bit dimming in two ways:
  1) scaling 8-bit components with global brightness r/g/b scalars
  2) calculating 5-bit dimming for each 48-bit pixel value
  Both work really well!
• Created SK9822 led-strip that's just like APA102's, with additional scaling to compensate for the fact that 5-bit dimming the SK9822 doesn't dim the LEDs as much and makes them bluer/greener.
• Per-strip scaling with separate red, green, blue factors.
• A number of casts added to resolve warnings from XCode's compiler.