### PR TITLE
Use bcm_host built-in library to determine peripheral base

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -7,7 +7,7 @@ SPIXELS_DIR=..
 
 SPIXELS_LIBRARY=$(SPIXELS_DIR)/lib/libspixels.a
 
-LDFLAGS=-L$(SPIXELS_DIR)/lib -lspixels
+LDFLAGS=-L$(SPIXELS_DIR)/lib -lspixels -L/opt/vc/lib -lbcm_host
 INCLUDE_FLAGS=-I$(SPIXELS_DIR)/include
 
 CXXFLAGS=-Wall -O3 $(INCLUDE_FLAGS)

--- a/lib/Makefile
+++ b/lib/Makefile
@@ -1,7 +1,7 @@
 LIB_OBJECTS=ft-gpio.o dma-multi-spi.o rpi-dma.o mailbox.o direct-multi-spi.o led-strip.o
 CFLAGS=-Wall -O3 $(INCLUDES) $(DEFINES)
 CXXFLAGS=$(CFLAGS)
-INCLUDES=-I../include -I.
+INCLUDES=-I../include -I. -I/opt/vc/include
 
 libspixels.a: $(LIB_OBJECTS)
 	ar rcs $@ $^


### PR DESCRIPTION
Instead of hardcoding a bunch of peripheral bases, the Raspberry Pi org's [documented](https://www.raspberrypi.org/documentation/hardware/raspberrypi/peripheral_addresses.md) way to do this is to use the `bcm_host` library. This will also ensure compatibility with future hardware revisions, even if the peripheral base changes.